### PR TITLE
Add golden-path repo templates for Go, Python, Node, Java and .NET

### DIFF
--- a/.github/workflows/validate-repo-templates.yaml
+++ b/.github/workflows/validate-repo-templates.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template: [go-app, python-app, node-app]
+        template: [go-app, python-app, node-app, java-app, dotnet-app]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/validate-repo-templates.yaml
+++ b/.github/workflows/validate-repo-templates.yaml
@@ -84,8 +84,23 @@ jobs:
       - name: Lint and render every chart
         run: |
           set -euo pipefail
-          for chart in repo-templates/*/skeleton/charts/app; do
-            echo "==> ${chart}"
+          pip install --quiet pyyaml
+          # Charts are linted AFTER rendering, not as they sit in the skeleton.
+          # A template that renders its chart (rather than exempting it with a
+          # raw glob) is full of scaffold expressions until it is scaffolded, so
+          # linting the skeleton would fail on a chart that is perfectly good.
+          for template in repo-templates/*/; do
+            name="$(basename "${template}")"
+            case "${name}" in _*|hack) continue ;; esac
+            chart="${RUNNER_TEMP}/${name}/charts/app"
+
+            repo-templates/hack/render-for-build.sh "${template}" "${RUNNER_TEMP}/${name}" >/dev/null
+            if [[ ! -d "${chart}" ]]; then
+              echo "==> ${name}: no chart, skipping"
+              continue
+            fi
+
+            echo "==> ${name}"
             helm lint "${chart}" --set image=ghcr.io/example/example:ci
             # Both shapes the stack actually deploys: in-cluster only, and
             # published through a Gateway with workload identity attached.

--- a/.github/workflows/validate-repo-templates.yaml
+++ b/.github/workflows/validate-repo-templates.yaml
@@ -1,0 +1,99 @@
+# Checks the repo templates under repo-templates/.
+#
+# Everything here is self-contained: no Wayfinder server, no credentials, no
+# cloud. The full render, using Wayfinder's own template engine, runs in the
+# wayfinder repository against a clone of this one.
+name: Validate repo templates
+
+on:
+  pull_request:
+    paths: ["repo-templates/**", ".github/workflows/validate-repo-templates.yaml"]
+  push:
+    branches: [main]
+    paths: ["repo-templates/**", ".github/workflows/validate-repo-templates.yaml"]
+
+permissions:
+  contents: read
+
+jobs:
+  structure:
+    name: Structure and glob coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check template structure
+        run: |
+          pip install --quiet pyyaml
+          python3 repo-templates/hack/check-templates.py
+
+      # The workflows are raw, so they are valid Actions YAML exactly as they
+      # sit on disk. Linting the canonical copy is enough: the check above
+      # proves every template's copy is byte-identical to it.
+      - name: Lint the shared workflows
+        uses: raven-actions/actionlint@v2
+        with:
+          files: "repo-templates/_shared/workflows/*.yaml"
+
+      - name: Shellcheck
+        run: |
+          shellcheck repo-templates/hack/*.sh \
+                     repo-templates/*.sh \
+                     repo-templates/*/skeleton/.wayfinder/*.sh
+
+  build:
+    name: Build ${{ matrix.template }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        template: [go-app, python-app, node-app]
+    steps:
+      - uses: actions/checkout@v6
+
+      # Substitutes placeholder values so the skeleton is a real project the
+      # language toolchain will accept. A template that does not compile, or
+      # whose own tests fail, cannot merge.
+      - name: Render the skeleton
+        run: repo-templates/hack/render-for-build.sh "repo-templates/${{ matrix.template }}" "${RUNNER_TEMP}/build"
+
+      - name: Set up the toolchain
+        working-directory: ${{ runner.temp }}/build
+        run: make ci-setup
+
+      - name: Lint
+        working-directory: ${{ runner.temp }}/build
+        run: make lint
+
+      - name: Test
+        working-directory: ${{ runner.temp }}/build
+        run: make test
+
+      - name: Build the image
+        working-directory: ${{ runner.temp }}/build
+        run: docker build --build-arg VERSION=ci -t "${{ matrix.template }}:ci" .
+
+  chart:
+    name: Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+
+      - name: Lint and render every chart
+        run: |
+          set -euo pipefail
+          for chart in repo-templates/*/skeleton/charts/app; do
+            echo "==> ${chart}"
+            helm lint "${chart}" --set image=ghcr.io/example/example:ci
+            # Both shapes the stack actually deploys: in-cluster only, and
+            # published through a Gateway with workload identity attached.
+            helm template rel "${chart}" --set image=ghcr.io/example/example:ci >/dev/null
+            helm template rel "${chart}" \
+              --set image=ghcr.io/example/example:ci \
+              --set httpRoute.enabled=true \
+              --set httpRoute.hostname=example.test \
+              --set httpRoute.parentGateway.name=shared \
+              --set env.BUCKET_NAME=example-bucket >/dev/null
+          done

--- a/repo-templates/ANATOMY.md
+++ b/repo-templates/ANATOMY.md
@@ -1,0 +1,103 @@
+# The two files, and which is which
+
+Every template here has two YAML files with confusingly similar names. They do
+completely different jobs, and knowing which is which makes everything else
+obvious.
+
+```
+repo-templates/go-app/
+├── RepoTemplate-go-app.yaml   ← you give this to Wayfinder
+├── wayfinder-template.yaml    ← Wayfinder reads this from the repository
+└── skeleton/                  ← what gets copied into the new repository
+```
+
+## `RepoTemplate-*.yaml` — the one you apply
+
+A Wayfinder object, like any other. It is a **pointer**: which repository, which
+branch or tag, and which directory inside it.
+
+```yaml
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: go-app
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  path: repo-templates/go-app
+  ref: main
+  displayName: Go service
+  category: service
+```
+
+```bash
+wf apply -f repo-templates/go-app/RepoTemplate-go-app.yaml
+```
+
+It carries no inputs and no file list, because it does not know any of that yet.
+All it knows is where to look. `displayName` and `category` are the catalogue's
+business — how the template is filed and filtered — rather than anything about
+the template's content.
+
+## `wayfinder-template.yaml` — the one in the repository
+
+Not a Wayfinder object at all. No `apiVersion`, no `kind`. This is the template
+*itself*: what it is called, what it asks the user for, and which of its files
+are copied verbatim.
+
+```yaml
+name: Go service
+description: >-
+  A Go HTTP service on net/http, deployed by a Wayfinder stack...
+icon: go
+inputs:
+  - name: serviceName
+    type: string
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+skeleton:
+  path: skeleton
+  raw:
+    - ".github/workflows/*.yaml"
+```
+
+**It contains no repository path, deliberately.** It does not know where it
+lives, and that is the point — the same file works read from a branch, a tag, a
+fork, or a different directory. Putting the path in both files would only give
+you two things that can disagree.
+
+## How they meet
+
+1. You apply the `RepoTemplate`.
+2. Wayfinder clones `spec.url` at `spec.ref` and looks in `spec.path`.
+3. It finds `wayfinder-template.yaml` there and parses it.
+4. It caches the result in the object's `status.manifest`, along with the exact
+   commit it read, and re-checks about once an hour.
+5. `wf create stack --from-template` prompts for the inputs that manifest
+   declares, renders `skeleton/` with the answers, and pushes the result as the
+   first commit of a new repository.
+
+Scaffolding always uses the pinned `status.commit`, not the tip of the branch —
+so what a user previewed is what they get, even if the template moves in between.
+
+```bash
+wf get repotemplate go-app -o yaml     # status.manifest is step 4
+```
+
+If `status.manifest` is empty, Wayfinder could not read the template: usually a
+wrong `spec.path`, a private repository, or a manifest that failed to parse.
+The object's status message says which.
+
+## The rest of the directory
+
+`skeleton/` is the only part that becomes the new repository. The
+`RepoTemplate-*.yaml`, the `wayfinder-template.yaml` and the template's own
+`README.md` all sit outside it and are never copied.
+
+Inside `skeleton/`, both file *contents* and file *paths* are rendered — which is
+why you will see directories like `cmd/${{ .Inputs.serviceName }}/` on disk. A
+path that renders to nothing is how a file is conditionally left out.
+
+The exception is `skeleton.raw`: those files are copied byte for byte. That
+matters for anything with its own `${{ }}` syntax — GitHub Actions workflows,
+Helm charts, CloudResourcePlans — which Wayfinder would otherwise try to
+evaluate. There are two ways to protect them and both are in use here on
+purpose; see the [README](./README.md) for which template demonstrates which.

--- a/repo-templates/DELIVERY-PIPELINE.md
+++ b/repo-templates/DELIVERY-PIPELINE.md
@@ -1,0 +1,102 @@
+# The delivery pipeline
+
+What the golden-path templates — [`go-app`](./go-app), [`python-app`](./python-app),
+[`node-app`](./node-app) — set up in a repository they create, and what you need
+in place before it works.
+
+## What the workflows do
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `<service>-pr<number>` is deployed and its URL commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | An image tagged `sha-<short sha>` is built and `<service>-develop` is deployed. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `<service>-prod`. |
+
+Cutting a release is therefore `git tag v1.0.0 && git push origin v1.0.0`.
+
+Production has two independent gates. GitHub's `environment: production` gate
+holds the deploy for your reviewers, and it is not decoration — it scopes the
+OIDC token to `repo:<owner>/<repo>:environment:production`, which is exactly what
+the production credential trusts. Setting the `WF_PROD_REQUIRE_APPROVAL` variable
+to `true` adds Wayfinder's own gate on the infrastructure plan, pausing per
+CloudResource until someone runs `wf approve cloudresource`.
+
+## Where configuration lives
+
+Nothing repository-specific is written into the workflow files. They are copied
+verbatim from the template so they stay upgradeable, and configuration splits in
+two:
+
+- **`.wayfinder/ci.env`**, written by Wayfinder when it creates the repository —
+  service name, tenant, environments, service account names, image repository.
+  Per-repository values go here.
+- **GitHub repository or organisation variables** — everything specific to your
+  Wayfinder installation, shared across repositories.
+
+| Variable | What it is |
+| --- | --- |
+| `WF_SERVER` | Wayfinder API URL. |
+| `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+| `WF_WORKSPACE` | Workspace to deploy into, when the template's `workspace` input was left blank. |
+| `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+| `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+| `WF_REGION` | Cloud region. |
+| `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+| `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides; each falls back to the value above. |
+| `WF_PROD_REQUIRE_APPROVAL` | `true` makes production deploys pause for infrastructure plan approval. |
+| `WF_PROD_APPROVAL_TIMEOUT` | How long to wait at each approval gate. `0` fails fast instead of waiting. |
+| `WF_EXPECT_INSTANCE_ID` | Asserts which Wayfinder installation production is talking to, guarding against a misconfigured `WF_SERVER`. |
+
+`.wayfinder/ci-env.sh` is the glue: each job runs it for its stage, and it
+resolves those two sources into the `WAYFINDER_*` variables the CLI reads, plus
+the deployment target flags.
+
+## Before CI can deploy
+
+These are the parts people miss.
+
+**1. Three service accounts, one per environment.** Each trusts a different
+GitHub OIDC subject, so a credential a pull request can use cannot reach
+production. Nothing long-lived is stored in the repository — GitHub mints a
+short-lived token per run and Wayfinder exchanges it.
+
+```bash
+TENANT=acme WORKSPACE=team-a REPO=acme/payments SERVICE=payments \
+  ./setup-ci-service-accounts.sh
+```
+
+See [`setup-ci-service-accounts.sh`](./setup-ci-service-accounts.sh) for what it
+creates and the imperative equivalents.
+
+**2. Catalogue write for the preview service account.** `Wayfinder.yaml` refers
+to its plan as `file:plans/...`, which publishes that plan to the workspace
+catalogue — and that happens on the dry run the `validate` job does, not just on
+a real deploy. Grant it, or set the `storagePlan` input to a catalogue reference
+such as `aws-s3-data-bucket@1.0.0` so nothing needs publishing.
+
+**3. GitHub environments `develop` and `production`.** Create both, with your
+reviewers on `production`. Without them GitHub will not mint the
+environment-scoped token these credentials trust, and the deploy jobs fail to
+authenticate.
+
+**4. The cluster must be able to pull your image.** Packages pushed to GHCR are
+private by default. Either make the package public or give the target namespace
+an image pull secret. This is the most common cause of a preview that deploys
+and then sits in `ImagePullBackOff` until the job times out.
+
+**5. A Gateway, if you want the service reachable.** Pass `gatewayName` (and
+`gatewayNamespace`) when scaffolding to publish through an existing Gateway API
+Gateway. Left blank, the service deploys and is reachable inside the cluster
+only, and the stack publishes no `url` output — the pull request comment says so
+rather than showing a link.
+
+## Naming
+
+| Thing | Convention | Example (`payments`, PR 42) |
+| --- | --- | --- |
+| Preview instance and namespace | `<service>-pr<N>` | `payments-pr42` |
+| Develop instance | `<service>-develop` | `payments-develop` |
+| Production instance | `<service>-prod` | `payments-prod` |
+| Service accounts | `<service>-ci-{preview,develop,prod}` | `payments-ci-prod` |
+| Image | `<registry>/<org>/<repo>:<tag>` | `ghcr.io/acme/payments:v1.2.3` |

--- a/repo-templates/README.md
+++ b/repo-templates/README.md
@@ -78,13 +78,19 @@ $ wf create stack payments --from-template go-app --input serviceName=payments \
 
 ```
 go-app/
-├── RepoTemplate-go-app.yaml   registers it with Wayfinder
-├── wayfinder-template.yaml    the template's name, description and inputs
-└── skeleton/                  the files that get copied, rendered with the inputs
+├── RepoTemplate-go-app.yaml   you give this to Wayfinder — a pointer
+├── wayfinder-template.yaml    Wayfinder reads this from the repository
+└── skeleton/                  the files that get copied into the new repository
 ```
 
-`wayfinder-template.yaml` is the definition, and it lives here rather than in
-Wayfinder — so the inputs and the files they fill in are versioned together.
+Two YAML files with similar names doing completely different jobs.
+**[ANATOMY.md](./ANATOMY.md) explains which is which**, and is the thing to read
+first if you have not worked with these before.
+
+The short version: the `RepoTemplate` says *where the template is*, the
+`wayfinder-template.yaml` at that path says *what the template is*. The manifest
+carries no repository path deliberately, so the same file works read from a
+branch, a tag or a fork.
 
 Registration points at the **directory** holding the manifest (`spec.path`),
 which is why one repository can hold all of these templates.

--- a/repo-templates/README.md
+++ b/repo-templates/README.md
@@ -18,6 +18,8 @@ production on a tag.
 | [`go-app/`](./go-app) | Go | `net/http` service, distroless static image |
 | [`python-app/`](./python-app) | Python | FastAPI on uv, venv on `python:3.13-slim` |
 | [`node-app/`](./node-app) | TypeScript | Fastify on `node:22-slim` |
+| [`java-app/`](./java-app) | Java | Spring Boot on Maven, `eclipse-temurin:21-jre` |
+| [`dotnet-app/`](./dotnet-app) | C# | ASP.NET Core minimal APIs, `aspnet:10.0-noble-chiseled` |
 
 They share one CI contract, one set of inputs and one stack shape, so moving
 between them is only a change of language. The stack is an app workload on

--- a/repo-templates/README.md
+++ b/repo-templates/README.md
@@ -4,6 +4,37 @@ Wayfinder [repository templates](https://on.wayfinder.run/docs/repo-templates/01
 repositories Wayfinder copies to create new ones, filling in the inputs whoever
 creates the repository supplies.
 
+There are two sets here, and they are for different things.
+
+## Golden paths
+
+Production-shaped services. Each one scaffolds a repository that builds a
+container image, deploys itself through Wayfinder, and arrives with a working
+delivery pipeline: pull request previews, deploy to develop on merge, deploy to
+production on a tag.
+
+| Template | Language | What you get |
+| -------- | -------- | ------------ |
+| [`go-app/`](./go-app) | Go | `net/http` service, distroless static image |
+| [`python-app/`](./python-app) | Python | FastAPI on uv, venv on `python:3.13-slim` |
+| [`node-app/`](./node-app) | TypeScript | Fastify on `node:22-slim` |
+
+They share one CI contract, one set of inputs and one stack shape, so moving
+between them is only a change of language. The stack is an app workload on
+Kubernetes plus an S3 bucket, wired together by workload identity — the pod
+reaches the bucket through its own cloud identity, and no credentials exist
+anywhere in the generated repository.
+
+**[DELIVERY-PIPELINE.md](./DELIVERY-PIPELINE.md) is the setup guide** — what the
+workflows do, the service accounts they need, and the GitHub variables to set.
+Read it before scaffolding one, because a template that deploys needs more
+groundwork than one that does not.
+
+## Teaching examples
+
+Smaller templates that each demonstrate one mechanic, and are what the docs walk
+through.
+
 | Template | What it creates | What it shows |
 | -------- | --------------- | ------------- |
 | [`go-microservice/`](./go-microservice) | A minimal Go service deploying a cloud resource | The worked example the docs walk through file by file. Keeps a CI workflow verbatim with a **`raw` glob** |
@@ -14,7 +45,8 @@ The first two overlap deliberately. A skeleton that ships GitHub Actions has to
 stop Wayfinder resolving Actions' own `${{ }}` expressions, and there are two
 ways to do it — exempt the file's contents entirely with `skeleton.raw`, or
 escape each expression with `$${{` and keep templating the rest of the file. One
-template demonstrates each.
+template demonstrates each. The golden paths use the `raw` approach, which keeps
+their four workflows byte-identical across every language.
 
 ## Try one
 
@@ -24,40 +56,71 @@ Creating a repository from one does need a connected GitHub organisation.
 
 ```bash
 # Register the template in your tenant's catalogue
-$ wf apply -f - <<'EOF'
-apiVersion: sourcecontrol/v3
-kind: RepoTemplate
-metadata:
-  name: go-service
-  labels:
-    language: go
-spec:
-  url: https://github.com/appvia/wayfinder-examples.git
-  path: repo-templates/go-service
-  ref: main
-  category: service
-EOF
+$ wf apply -f repo-templates/go-app/RepoTemplate-go-app.yaml
 
 # Check Wayfinder could read it
-$ wf get repotemplate go-service -o yaml
+$ wf get repotemplate go-app -o yaml
 
 # See what it produces, creating nothing
-$ wf create stack payments --from-template go-service --input serviceName=payments --dry-run
+$ wf create stack payments --from-template go-app --input serviceName=payments --dry-run
 
 # Create the repository and the stack for real
-$ wf create stack payments --from-template go-service --input serviceName=payments
+$ wf create stack payments --from-template go-app --input serviceName=payments \
+    --github-org github.acme --workspace team-a
 ```
+
+`serviceName` is the only required input on every template here. Run
+`wf get repotemplate <name> -o yaml` to see the rest with their defaults.
 
 ## How a template is laid out
 
 ```
-go-service/
-├── wayfinder-template.yaml   the template's name, description and inputs
-└── skeleton/                 the files that get copied, rendered with the inputs
+go-app/
+├── RepoTemplate-go-app.yaml   registers it with Wayfinder
+├── wayfinder-template.yaml    the template's name, description and inputs
+└── skeleton/                  the files that get copied, rendered with the inputs
 ```
 
 `wayfinder-template.yaml` is the definition, and it lives here rather than in
 Wayfinder — so the inputs and the files they fill in are versioned together.
 
-Registration points at the **directory** holding the manifest (`path` above),
-which is why one repository can hold both of these templates.
+Registration points at the **directory** holding the manifest (`spec.path`),
+which is why one repository can hold all of these templates.
+
+## Working on the templates
+
+- **Language differences live in the `Makefile`.** The golden paths' CI calls
+  `make ci-setup`, `make test`, `make lint` and `make build` and nothing else.
+  That is what lets the four workflows stay identical across languages.
+- **All the golden paths ship the same workflows.** Edit
+  [`_shared/workflows/`](./_shared/workflows), copy the result into each one, and
+  CI checks they still match.
+- **`Wayfinder.yaml` is the one file mixing engines.** It is rendered, so every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` to survive as
+  a literal `${{ ... }}`. Get this wrong and it fails when someone creates a
+  repository — check with `--dry-run` before merging.
+- **Raw glob gotchas.** They are matched with Go's `path.Match`: there is no
+  `**`, a `*` never crosses a `/`, and `*.yaml` does not match `*.yml`.
+
+### Checking your work
+
+```bash
+# Structure, glob coverage, escaping and workflow drift. No server needed.
+pip install pyyaml && python3 repo-templates/hack/check-templates.py
+
+# Compile and test one skeleton locally.
+repo-templates/hack/render-for-build.sh repo-templates/go-app /tmp/out
+cd /tmp/out && make ci-setup && make lint && make test
+```
+
+CI runs both of those, plus `actionlint`, `helm lint` and a container build for
+every golden path. The full render, using Wayfinder's own template engine, runs
+from the wayfinder repository:
+
+```bash
+WF_EXAMPLES_DIR=$PWD go test -count=1 \
+  ./server/sourcecontrol/services/repotemplates/ -run Example
+```
+
+Pass `-count=1` — the templates live outside that module, so editing one does
+not invalidate Go's test cache and a stale pass is easy to believe.

--- a/repo-templates/_shared/workflows/ci.yaml
+++ b/repo-templates/_shared/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/_shared/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/_shared/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/_shared/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/_shared/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/_shared/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/_shared/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/dotnet-app/README.md
+++ b/repo-templates/dotnet-app/README.md
@@ -1,0 +1,75 @@
+# .NET service template
+
+A C# service on ASP.NET Core minimal APIs, targeting .NET 10, with a Wayfinder
+stack that runs it on Kubernetes alongside an S3 bucket it reaches through
+workload identity.
+
+This directory is the template definition. It is not itself a .NET project — the
+project lives under `skeleton/`, and only that is written into a new repository.
+
+The assembly is a fixed `Service` rather than one named after the service, for the
+same reason the Java template fixes its package: renaming is one refactor, whereas
+templating a project name threads it through the csproj, the test project, the
+published DLL and the container entrypoint.
+
+| File | What it is |
+| --- | --- |
+| `wayfinder-template.yaml` | The template: its inputs, and which files are copied raw. |
+| `RepoTemplate-dotnet-app.yaml` | Registers the template with Wayfinder. |
+| `skeleton/` | Everything written into the generated repository. |
+
+## Using it
+
+```bash
+wf apply -f RepoTemplate-dotnet-app.yaml
+wf create stack payments --from-template dotnet-app --input serviceName=payments --dry-run
+```
+
+Drop `--dry-run` and add `--github-org` and `--workspace` to create the
+repository for real. See [../DELIVERY-PIPELINE.md](../DELIVERY-PIPELINE.md) for what CI does and what it needs first.
+
+## What the generated repository contains
+
+```
+payments/
+├── README.md
+├── Wayfinder.yaml              app + S3 bucket, wired by workload identity
+├── Makefile                    ci-setup / test / lint / build — what CI calls
+├── Dockerfile                  aspnet:10.0-noble-chiseled, non-root
+├── src/Service/                Service.csproj, Program.cs
+├── tests/Service.Tests/        EndpointTests.cs
+├── charts/app/                 the workload chart
+├── plans/                      the CloudResourcePlan for the bucket
+├── .wayfinder/                 ci.env (this repo's identity) + ci-env.sh
+└── .github/workflows/          ci · preview teardown · deploy develop · deploy prod
+```
+
+## Inputs
+
+`serviceName` is the only required one. It is used for the package name,
+the image name, the Helm release and the stack instance names.
+
+Everything else is optional and defaulted, so `--input serviceName=payments
+--no-input` is enough to scaffold from CI. The two worth setting deliberately:
+
+- `gatewayName` — name an existing Gateway API Gateway to publish the service.
+  Left blank, the service deploys but is reachable in-cluster only.
+- `workspace` — leave blank to take the workspace from the `WF_WORKSPACE`
+  GitHub variable instead, which is better when one workspace serves many
+  repositories.
+
+Run `wf get repotemplate dotnet-app -o yaml` to see the full list with defaults.
+
+## Editing this template
+
+- **`skeleton/.github/workflows/*` and `skeleton/charts/**` are raw.** They are
+  copied byte for byte and never rendered, so they must not contain `${{ }}` or
+  `$${{ }}` meant for the scaffolder. Per-repository values belong in
+  `skeleton/.wayfinder/ci.env`, which is rendered.
+- **`skeleton/Wayfinder.yaml` is rendered and mixes two engines.** Every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` so it
+  survives scaffolding as a literal `${{ ... }}`. Getting this wrong fails at
+  the moment someone creates a repository, so check it with `--dry-run`.
+- The workflows are shared across all four templates in this repository. Edit
+  `../_shared/workflows/`, copy the result into every template, and CI will
+  check they match.

--- a/repo-templates/dotnet-app/README.md
+++ b/repo-templates/dotnet-app/README.md
@@ -4,6 +4,10 @@ A C# service on ASP.NET Core minimal APIs, targeting .NET 10, with a Wayfinder
 stack that runs it on Kubernetes alongside an S3 bucket it reaches through
 workload identity.
 
+`RepoTemplate-dotnet-app.yaml` is the object you give Wayfinder — a pointer at this
+directory. `wayfinder-template.yaml` is the template itself, which Wayfinder
+reads once it has followed that pointer. See [../ANATOMY.md](../ANATOMY.md).
+
 This directory is the template definition. It is not itself a .NET project — the
 project lives under `skeleton/`, and only that is written into a new repository.
 

--- a/repo-templates/dotnet-app/RepoTemplate-dotnet-app.yaml
+++ b/repo-templates/dotnet-app/RepoTemplate-dotnet-app.yaml
@@ -1,0 +1,30 @@
+# Registers the .NET minimal API service template with Wayfinder.
+#
+# This repository is public, so Wayfinder reads the template anonymously — no
+# GitHub connection is needed to register it or to preview what it renders.
+# Creating a repository from it does need a connected GitHub organisation.
+#
+#   wf apply -f RepoTemplate-dotnet-app.yaml
+#   wf get repotemplate dotnet-app -o yaml     # check status.manifest synced
+#   wf create stack payments --from-template dotnet-app --input serviceName=payments --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: dotnet-app
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: csharp
+    framework: aspnetcore
+    family: wayfinder-golden-path
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/dotnet-app
+  # Branch or tag to read. Pin this to a tag to hold the template steady —
+  # tracking a branch means every merge changes the template for everyone on the
+  # next resync. Point it at a branch to try a change before merging it.
+  ref: main
+  displayName: .NET minimal API service
+  category: service

--- a/repo-templates/dotnet-app/skeleton/.dockerignore
+++ b/repo-templates/dotnet-app/skeleton/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.wayfinder
+**/bin
+**/obj
+publish
+tests
+charts
+plans
+Wayfinder.yaml
+wayfinder-stack.yaml
+README.md

--- a/repo-templates/dotnet-app/skeleton/.github/dependabot.yml
+++ b/repo-templates/dotnet-app/skeleton/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps this repository current on its own, rather than relying on the template
+# it was scaffolded from being re-run.
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      nuget-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/repo-templates/dotnet-app/skeleton/.github/workflows/ci.yaml
+++ b/repo-templates/dotnet-app/skeleton/.github/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/dotnet-app/skeleton/.github/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/dotnet-app/skeleton/.github/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/dotnet-app/skeleton/.github/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/dotnet-app/skeleton/.github/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/dotnet-app/skeleton/.github/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/dotnet-app/skeleton/.github/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/dotnet-app/skeleton/.gitignore
+++ b/repo-templates/dotnet-app/skeleton/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+publish/
+
+# Written by `wf up` to remember the stack instance you last deployed to.
+.wfup

--- a/repo-templates/dotnet-app/skeleton/.wayfinder/ci-env.sh
+++ b/repo-templates/dotnet-app/skeleton/.wayfinder/ci-env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Resolves the Wayfinder context for one CI stage and exports it to the job.
+#
+#   usage: .wayfinder/ci-env.sh <preview|develop|prod>
+#
+# Reads .wayfinder/ci.env, which Wayfinder wrote when this repository was
+# scaffolded, combines it with the WF_* GitHub variables set on the repository
+# or organisation, and writes the result to $GITHUB_ENV so later steps can use
+# it directly. Deployment target flags are written one per line to a file whose
+# path lands in WF_DEPLOY_ARGS_FILE; read them with `mapfile -t args < "$FILE"`.
+#
+# Exports:
+#   WAYFINDER_TENANT, WAYFINDER_WORKSPACE, WAYFINDER_ENVIRONMENT
+#   WAYFINDER_SERVICE_ACCOUNT  the CLI authenticates with this implicitly
+#   WF_INSTANCE                the stack instance for this stage
+#   WF_DEPLOY_ARGS_FILE        --target/--identity/--region/--dns-zone flags
+#   plus everything in .wayfinder/ci.env
+set -euo pipefail
+
+stage="${1:-}"
+if [[ -z "${stage}" ]]; then
+  echo "::error::usage: .wayfinder/ci-env.sh <preview|develop|prod>"
+  exit 1
+fi
+
+# shellcheck source=ci.env disable=SC1091
+source .wayfinder/ci.env
+
+case "${stage}" in
+  preview)
+    if [[ -z "${PR_NUMBER:-}" ]]; then
+      echo "::error::PR_NUMBER must be set for the preview stage."
+      exit 1
+    fi
+    environment="${WF_ENV_PREVIEW}"
+    account="${WF_SA_PREVIEW}"
+    instance="${WF_SERVICE_NAME}-pr${PR_NUMBER}"
+    ;;
+  develop)
+    environment="${WF_ENV_DEVELOP}"
+    account="${WF_SA_DEVELOP}"
+    instance="${WF_INSTANCE_DEVELOP}"
+    ;;
+  prod)
+    environment="${WF_ENV_PROD}"
+    account="${WF_SA_PROD}"
+    instance="${WF_INSTANCE_PROD}"
+    ;;
+  *)
+    echo "::error::Unknown stage '${stage}'. Expected preview, develop or prod."
+    exit 1
+    ;;
+esac
+
+# The workspace is a scaffold-time input. Where it was left blank, fall back to
+# the WF_WORKSPACE repository or organisation variable, which is the better
+# place for it when one workspace serves many repositories.
+workspace="${WF_WORKSPACE:-${WF_WORKSPACE_VAR:-}}"
+if [[ -z "${workspace}" ]]; then
+  echo "::error::No Wayfinder workspace. Set the WF_WORKSPACE repository or organisation variable."
+  exit 1
+fi
+
+args_file="${RUNNER_TEMP:-/tmp}/wf-deploy-args"
+: >"${args_file}"
+
+# A cluster in the workspace and environment already selected above, narrowed to
+# a namespace named after the instance so each deployment is isolated.
+if [[ -n "${WF_HOST_CLUSTER:-}" ]]; then
+  printf '%s\n' "--target" "k8s:${WF_HOST_CLUSTER}:${instance}" >>"${args_file}"
+fi
+# The cloud identity Wayfinder provisions cloud resources through. Wayfinder
+# reads the account it reaches, so no separate --target is needed for the cloud.
+if [[ -n "${WF_IDENTITY:-}" ]]; then
+  printf '%s\n' "--identity" "${WF_IDENTITY}" >>"${args_file}"
+fi
+if [[ -n "${WF_REGION:-}" ]]; then
+  printf '%s\n' "--region" "${WF_REGION}" >>"${args_file}"
+fi
+if [[ -n "${WF_DNS_ZONE:-}" ]]; then
+  printf '%s\n' "--dns-zone" "${WF_DNS_ZONE}" >>"${args_file}"
+fi
+
+{
+  # $GITHUB_ENV accepts KEY=value lines only, so the comments in ci.env are
+  # filtered out rather than passed through.
+  grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env
+  echo "WF_INSTANCE=${instance}"
+  echo "WF_DEPLOY_ARGS_FILE=${args_file}"
+  echo "WAYFINDER_TENANT=${WF_TENANT}"
+  echo "WAYFINDER_WORKSPACE=${workspace}"
+  echo "WAYFINDER_ENVIRONMENT=${environment}"
+  echo "WAYFINDER_SERVICE_ACCOUNT=${WF_TENANT}:${workspace}:${account}"
+} >>"${GITHUB_ENV:?GITHUB_ENV is not set; this script is meant to run in GitHub Actions}"
+
+echo "Stage ${stage}: instance ${instance} in ${WF_TENANT}:${workspace}:${environment}"
+echo "Deploying as service account ${WF_TENANT}:${workspace}:${account}"

--- a/repo-templates/dotnet-app/skeleton/.wayfinder/ci.env
+++ b/repo-templates/dotnet-app/skeleton/.wayfinder/ci.env
@@ -1,0 +1,36 @@
+# Wayfinder wrote this file when it created this repository.
+#
+# It holds the values that identify THIS repository to Wayfinder. Every CI job
+# loads it, so this is where to add a new per-repository value — the workflows
+# themselves are copied verbatim from the template and carry no repository
+# specifics.
+#
+# Values that differ per Wayfinder installation rather than per repository
+# (server URL, host cluster, cloud identity, DNS zone) are GitHub repository or
+# organisation variables instead. See .github/workflows/ and the template README.
+
+# Identity
+WF_SERVICE_NAME=${{ .Inputs.serviceName }}
+WF_TENANT=${{ .Tenant }}
+# Blank means "use the WF_WORKSPACE GitHub variable".
+WF_WORKSPACE=${{ .Inputs.workspace }}
+WF_APP_PORT=${{ .Inputs.port }}
+
+# Environments
+WF_ENV_PREVIEW=${{ .Inputs.previewEnvironment }}
+WF_ENV_DEVELOP=${{ .Inputs.developEnvironment }}
+WF_ENV_PROD=${{ .Inputs.prodEnvironment }}
+
+# Stack instances. Preview instances are named <service>-pr<number> at run time.
+WF_INSTANCE_DEVELOP=${{ .Inputs.serviceName }}-develop
+WF_INSTANCE_PROD=${{ .Inputs.serviceName }}-prod
+
+# Service accounts, one per environment, so a leaked preview credential cannot
+# deploy to production. Each is <tenant>:<workspace>:<name> at run time.
+WF_SA_PREVIEW=${{ .Inputs.serviceName }}-ci-preview
+WF_SA_DEVELOP=${{ .Inputs.serviceName }}-ci-develop
+WF_SA_PROD=${{ .Inputs.serviceName }}-ci-prod
+
+# Container image
+WF_IMAGE_REGISTRY=${{ .Inputs.registry }}
+WF_IMAGE_REPO=${{ .Inputs.registry }}/${{ .Repo.Organization }}/${{ .Repo.Name }}

--- a/repo-templates/dotnet-app/skeleton/Dockerfile
+++ b/repo-templates/dotnet-app/skeleton/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build -----------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+WORKDIR /src
+
+# Project files first, so a source-only change reuses the cached restore.
+COPY src/Service/Service.csproj src/Service/
+RUN dotnet restore src/Service/Service.csproj
+
+COPY src ./src
+
+# VERSION is passed by CI: the git tag for a release, the short SHA otherwise.
+ARG VERSION=dev
+# VERSION is unset for this one command. Docker turns a build arg into an
+# environment variable, MSBuild reads environment variables as properties, and
+# it would take a value like "v1.2.3" or "sha-abc1234" as the assembly Version —
+# which is not a valid NuGet version and fails the publish. The release still
+# reaches the running service through ENV RELEASE below.
+RUN VERSION= dotnet publish src/Service/Service.csproj \
+      --configuration Release \
+      --no-restore \
+      -o /publish
+
+# ---- Run -------------------------------------------------------------------
+# Chiseled: an Ubuntu base cut down to what the runtime needs, with no shell and
+# no package manager, and it runs as a non-root user out of the box.
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled
+
+ARG VERSION=dev
+ENV RELEASE=${VERSION} \
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+WORKDIR /app
+COPY --from=build /publish .
+
+USER $APP_UID
+EXPOSE ${{ .Inputs.port }}
+
+ENTRYPOINT ["dotnet", "Service.dll"]

--- a/repo-templates/dotnet-app/skeleton/Makefile
+++ b/repo-templates/dotnet-app/skeleton/Makefile
@@ -1,0 +1,60 @@
+# The CI workflows call `make ci-setup`, `make test`, `make lint` and
+# `make build` and nothing else. That is deliberate: it keeps the workflows
+# identical across every Wayfinder service template, whatever the language.
+# Change how this service is built here, not in .github/workflows/.
+RELEASE ?= dev
+
+APP := src/Service
+TESTS := tests/Service.Tests
+
+DOTNET := dotnet --nologo
+
+.PHONY: all
+all: lint test
+
+# GitHub runners ship a .NET SDK, but not necessarily this major version. Install
+# it only when it is missing, so a runner that already has it costs nothing.
+.PHONY: ci-setup
+ci-setup:
+	@if $(DOTNET) --list-sdks 2>/dev/null | grep -q '^10\.'; then \
+		echo "found .NET 10 SDK"; \
+	else \
+		echo "installing the .NET 10 SDK"; \
+		curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; \
+		bash /tmp/dotnet-install.sh --channel 10.0 --install-dir "$$HOME/.dotnet"; \
+		echo "$$HOME/.dotnet" >> $${GITHUB_PATH:-/dev/null}; \
+	fi
+	$(DOTNET) --version
+
+.PHONY: test
+test:
+	$(DOTNET) test $(TESTS)
+
+# TreatWarningsAsErrors is set in both csproj files, so a warning fails this.
+# `format --verify-no-changes` is the formatting half.
+.PHONY: lint
+lint:
+	$(DOTNET) build $(APP) --configuration Release
+	$(DOTNET) format $(APP) --verify-no-changes
+	$(DOTNET) format $(TESTS) --verify-no-changes
+
+.PHONY: format
+format:
+	$(DOTNET) format $(APP)
+	$(DOTNET) format $(TESTS)
+
+.PHONY: build
+build:
+	$(DOTNET) publish $(APP) --configuration Release -o ./publish
+
+.PHONY: run
+run:
+	$(DOTNET) run --project $(APP)
+
+.PHONY: image
+image:
+	docker build --build-arg VERSION=$(RELEASE) -t ${{ .Inputs.serviceName }}:$(RELEASE) .
+
+.PHONY: clean
+clean:
+	rm -rf publish $(APP)/bin $(APP)/obj $(TESTS)/bin $(TESTS)/obj

--- a/repo-templates/dotnet-app/skeleton/Makefile
+++ b/repo-templates/dotnet-app/skeleton/Makefile
@@ -7,7 +7,7 @@ RELEASE ?= dev
 APP := src/Service
 TESTS := tests/Service.Tests
 
-DOTNET := dotnet --nologo
+DOTNET := dotnet
 
 .PHONY: all
 all: lint test
@@ -28,13 +28,13 @@ ci-setup:
 
 .PHONY: test
 test:
-	$(DOTNET) test $(TESTS)
+	$(DOTNET) test $(TESTS) --nologo
 
 # TreatWarningsAsErrors is set in both csproj files, so a warning fails this.
 # `format --verify-no-changes` is the formatting half.
 .PHONY: lint
 lint:
-	$(DOTNET) build $(APP) --configuration Release
+	$(DOTNET) build $(APP) --configuration Release --nologo
 	$(DOTNET) format $(APP) --verify-no-changes
 	$(DOTNET) format $(TESTS) --verify-no-changes
 
@@ -45,7 +45,7 @@ format:
 
 .PHONY: build
 build:
-	$(DOTNET) publish $(APP) --configuration Release -o ./publish
+	$(DOTNET) publish $(APP) --configuration Release --nologo -o ./publish
 
 .PHONY: run
 run:

--- a/repo-templates/dotnet-app/skeleton/README.md
+++ b/repo-templates/dotnet-app/skeleton/README.md
@@ -1,0 +1,130 @@
+# ${{ .Inputs.serviceName }}
+
+${{ .Inputs.description }}
+
+Scaffolded by Wayfinder from the `dotnet-app` template.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `src/Service/` | The service. ASP.NET Core minimal APIs with `/`, `/healthz` and `/readyz`. |
+| `tests/Service.Tests/` | The xUnit suite, driven through `WebApplicationFactory`. |
+| `Wayfinder.yaml` | The stack: what gets deployed and what it needs. |
+| `charts/app/` | The Helm chart for the workload. |
+| `plans/` | The CloudResourcePlan backing the storage component. |
+| `.wayfinder/ci.env` | This repository's Wayfinder identity, read by every CI job. |
+| `.github/workflows/` | Pull request previews, deploy to develop, deploy to production. |
+
+## Running it locally
+
+```bash
+make ci-setup # install the .NET 10 SDK, if you do not have it
+make test     # dotnet test
+make lint     # dotnet build (warnings are errors) and dotnet format --verify-no-changes
+make run      # dotnet run on port ${{ .Inputs.port }}
+```
+
+```bash
+curl localhost:${{ .Inputs.port }}/healthz
+curl localhost:${{ .Inputs.port }}/
+```
+
+## Deploying it
+
+CI deploys this service for you. If you want to deploy a copy of your own from
+your laptop, into your own instance:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+wf down -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+```
+
+`wf up` needs an image to run, so pass one that already exists:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER --env-var IMAGE=<registry>/<org>/<repo>:<tag> --env-var RELEASE=local
+```
+
+## How CI works
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `${{ .Inputs.serviceName }}-pr<number>` is deployed in `${{ .Inputs.previewEnvironment }}` and its URL is commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | Tests run, an image tagged `sha-<short sha>` is built, and `${{ .Inputs.serviceName }}-develop` is deployed in `${{ .Inputs.developEnvironment }}`. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `${{ .Inputs.serviceName }}-prod` in `${{ .Inputs.prodEnvironment }}`. |
+
+Cutting a release is therefore:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Where CI configuration lives
+
+Nothing repository-specific is written into the workflow files — they are
+copied verbatim from the template so they stay upgradeable. Configuration
+splits in two:
+
+- **`.wayfinder/ci.env`** — values specific to this repository: the service
+  name, tenant, environments, service accounts and image repository. Add new
+  per-repository values here.
+- **GitHub repository or organisation variables** — values specific to your
+  Wayfinder installation, shared by every repository:
+
+  | Variable | What it is |
+  | --- | --- |
+  | `WF_SERVER` | Wayfinder API URL. |
+  | `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+  | `WF_WORKSPACE` | Workspace to deploy into, when `.wayfinder/ci.env` leaves it blank. |
+  | `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+  | `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+  | `WF_REGION` | Cloud region. |
+  | `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+  | `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides. Each falls back to the value above. |
+  | `WF_PROD_REQUIRE_APPROVAL` | Set to `true` to make production deploys pause for plan approval. |
+  | `WF_EXPECT_INSTANCE_ID` | Guards production against a misconfigured `WF_SERVER`. |
+
+### What CI needs before it can run
+
+Three Wayfinder service accounts, one per environment, each trusting a
+different GitHub OIDC subject so a preview credential cannot reach production:
+
+```bash
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-preview -w <workspace>
+wf create serviceaccountcredential github-preview \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-preview \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-pull-request
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-develop -w <workspace>
+wf create serviceaccountcredential github-develop \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-develop \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment develop
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-prod -w <workspace>
+wf create serviceaccountcredential github-prod \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-prod \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment production
+```
+
+Each needs the `deployer` role in its environment. The preview account also
+needs catalogue write, because `Wayfinder.yaml` refers to its plan as
+`file:plans/...`, which publishes that plan to the workspace catalogue — and
+that happens on a dry run too.
+
+You also need GitHub environments named `develop` and `production` (put your
+reviewers on `production`), and the cluster must be able to pull your image.
+Packages published to GHCR are private by default, so either make the package
+public or give the cluster an image pull secret.
+
+## Storage
+
+`Wayfinder.yaml` provisions an S3 bucket per stack instance and grants this
+service read-write access to it. The bucket name arrives as `BUCKET_NAME`.
+There are no credentials anywhere in this repository: the pod authenticates
+with its own cloud identity, which Wayfinder attaches to its Kubernetes service
+account.
+
+To drop the bucket, remove the `storage` component from `Wayfinder.yaml` along
+with the `workloadIdentity` block and the `env` entries that reference it.

--- a/repo-templates/dotnet-app/skeleton/Wayfinder.yaml
+++ b/repo-templates/dotnet-app/skeleton/Wayfinder.yaml
@@ -1,0 +1,87 @@
+# The Wayfinder stack for this service: what gets deployed, and what it needs.
+#
+# Two things here are filled in when you deploy, not when you edit:
+#
+#   $${{ ... }}  A Wayfinder stack expression. Component outputs, workload
+#               identity annotations and variables are resolved at deploy time.
+#   ${NAME}     Supplied by CI with `wf deploy --env-var NAME=value`. Every one
+#               must resolve, and an --env-var nothing references is rejected.
+#
+# Deploy it yourself with `wf up -i <instance>`; see `wf deploy --help`.
+apiVersion: v1
+name: ${{ .Stack.Name }}
+description: "${{ .Inputs.description }}"
+
+# Deploy-time settings you can vary per environment without editing this file:
+#   wf set var replicas --value 3 -w <workspace> -e prod
+# Values resolve down the tenant > workspace > environment > instance hierarchy.
+vars:
+  - name: replicas
+    description: Number of pods to run.
+    type: number
+    optional: true
+    defaultValue: 1
+
+components:
+${{- if .Inputs.includeStorage }}
+  # An S3 bucket for this service's data, created per stack instance — every
+  # preview, develop and production deployment gets its own.
+  #
+  # This is a provider component: it publishes consumption policies rather than
+  # credentials. The `app` component below is granted one of them, and Wayfinder
+  # turns that grant into the IAM policy on the workload's own identity. No
+  # access keys exist anywhere in this repository.
+  storage:
+    type: CloudResource
+    plan: ${{ .Inputs.storagePlan }}
+    inputs:
+      - name: suffix
+        value: data
+${{ end }}
+  app:
+    type: KubeResource
+${{- if .Inputs.gatewayName }}
+    outputs:
+      - name: url
+        description: Public URL of the service.
+        valueTemplate: "https://$${{ getDNSEntry }}"
+${{- end }}
+${{- if .Inputs.includeStorage }}
+    workloadIdentity:
+      serviceAccountName: ${{ .Inputs.serviceName }}
+      access:
+        - to: storage
+          consumptionPolicy: read-write
+${{- end }}
+    helm:
+      chartPath: charts/app
+      chartName: app
+      valuesTemplate: |
+        image: "${IMAGE}"
+        release: "${RELEASE}"
+        port: ${{ .Inputs.port }}
+        replicas: $${{ .Vars.replicas }}
+        serviceAccount:
+          name: ${{ .Inputs.serviceName }}
+${{- if .Inputs.includeStorage }}
+          annotations:
+        $${{ .WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+        env:
+          BUCKET_NAME: "$${{ .Components.storage.s3_bucket_id }}"
+          BUCKET_ARN: "$${{ .Components.storage.s3_bucket_arn }}"
+${{- end }}
+        httpRoute:
+${{- if .Inputs.gatewayName }}
+          enabled: true
+          hostname: "$${{ getDNSEntry }}"
+          parentGateway:
+            name: ${{ .Inputs.gatewayName }}
+${{- if .Inputs.gatewayNamespace }}
+            namespace: ${{ .Inputs.gatewayNamespace }}
+${{- end }}
+${{- else }}
+          # No Gateway was named when this repository was scaffolded, so the
+          # service is reachable inside the cluster only. To publish it, set
+          # httpRoute.enabled and name a Gateway that exists in this environment.
+          enabled: false
+${{- end }}

--- a/repo-templates/dotnet-app/skeleton/charts/app/Chart.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: The workload for this service, deployed by the Wayfinder stack in Wayfinder.yaml.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/repo-templates/dotnet-app/skeleton/charts/app/templates/_helpers.tpl
+++ b/repo-templates/dotnet-app/skeleton/charts/app/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.serviceAccountName" -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.release | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/repo-templates/dotnet-app/skeleton/charts/app/templates/deployment.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Rolls the pods when the release changes even if the image tag does not.
+        wayfinder.appvia.io/release: {{ .Values.release | quote }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ include "app.name" . }}
+          image: {{ required "image is required; it is supplied by CI as ${IMAGE}" .Values.image | quote }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: RELEASE
+              value: {{ .Values.release | quote }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/repo-templates/dotnet-app/skeleton/charts/app/templates/httproute.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ required "httpRoute.parentGateway.name is required when httpRoute.enabled is true" .Values.httpRoute.parentGateway.name }}
+      {{- with .Values.httpRoute.parentGateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled is true" .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "app.fullname" . }}
+          port: {{ .Values.port }}
+{{- end }}

--- a/repo-templates/dotnet-app/skeleton/charts/app/templates/service.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/repo-templates/dotnet-app/skeleton/charts/app/templates/serviceaccount.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  # Wayfinder puts the cloud workload identity annotations here, which is how
+  # the pod authenticates to its cloud resources without any stored credentials.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/repo-templates/dotnet-app/skeleton/charts/app/values.yaml
+++ b/repo-templates/dotnet-app/skeleton/charts/app/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for a standalone `helm template`. In a real deployment every value
+# here is overwritten by the valuesTemplate in Wayfinder.yaml, which is where
+# the image tag, the workload identity annotations and the storage outputs come
+# from. Edit Wayfinder.yaml, not this file, unless you are adding a new value.
+
+# Container image reference. CI supplies this as ${IMAGE} at deploy time.
+image: ""
+
+# The release this is: a git tag, or sha-<short sha>.
+release: dev
+
+port: 8080
+replicas: 1
+
+serviceAccount:
+  name: app
+  # Wayfinder writes the cloud workload identity annotations here. That is what
+  # lets the pod reach its cloud resources with no credentials in the cluster.
+  annotations: {}
+
+# Environment variables for the container, as a plain name/value map.
+env: {}
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentGateway:
+    name: ""
+    # Leave blank when the Gateway is in this service's own namespace.
+    namespace: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/repo-templates/dotnet-app/skeleton/plans/aws-s3-data-bucket.yaml
+++ b/repo-templates/dotnet-app/skeleton/plans/aws-s3-data-bucket.yaml
@@ -1,0 +1,144 @@
+apiVersion: cloudresources/v3
+kind: CloudResourcePlan
+metadata:
+  name: aws-s3-data-bucket
+  version: "1.0.0"
+spec:
+  cloud: aws
+  description: "S3 bucket for application data, with read-only / read-write / write-only consumption policies that other components can be granted."
+  inputs:
+    - name: versioning
+      description: "Enable object versioning. Use with caution — makes deletion harder."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: disable_force_destroy
+      description: "Disable force destroy. Use with caution — teardown will fail while objects remain."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: suffix
+      description: "Differentiates buckets within a stack instance. Combined with stack+instance to form the bucket prefix."
+      type: string
+      optional: true
+      defaultValue: "data"
+
+  # This is a PROVIDER plan: it has no workload identity of its own. Instead it
+  # publishes consumption policies that other components can be granted from the
+  # manifest. Wayfinder turns a grant into the IAM policy below and attaches it to
+  # the consumer's role — no IAM written by hand.
+  consumptionPolicies:
+    - name: read-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: read-write
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadWrite",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: write-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppWriteOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+
+  terraform:
+    modules:
+      - name: s3_bucket
+        source: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+        version: "v4.1.2"
+    files:
+      - name: main.tf
+        template: |
+          module "s3_bucket" {
+            source = ${{ .Modules.s3_bucket.Source | quote }}
+
+            bucket_prefix = "${{ .Stack.Name }}-${{ .Stack.Instance.Name }}-${{ .Inputs.suffix }}-"
+
+            ${{- if .Inputs.versioning }}
+            versioning = {
+              enabled = true
+            }
+            ${{- end }}
+
+            server_side_encryption_configuration = {
+              rule = {
+                apply_server_side_encryption_by_default = {
+                  sse_algorithm = "AES256"
+                }
+              }
+            }
+
+            # AWS blocks public access on new buckets by default; don't attach a
+            # public policy (and avoid s3:PutBucketPublicAccessBlock, which some
+            # account guardrails deny).
+            attach_public_policy = false
+
+            ${{- if not .Inputs.disable_force_destroy }}
+            force_destroy = true
+            ${{- end }}
+
+            tags = {
+              Application = "${{ .Stack.Name }}"
+              Environment = "${{ .Stack.Instance.Name }}"
+              ManagedBy   = "Wayfinder"
+            }
+          }
+      - name: outputs.tf
+        template: |
+          output "s3_bucket_arn" {
+            value = module.s3_bucket.s3_bucket_arn
+          }
+          output "s3_bucket_id" {
+            value = module.s3_bucket.s3_bucket_id
+          }

--- a/repo-templates/dotnet-app/skeleton/src/Service/Program.cs
+++ b/repo-templates/dotnet-app/skeleton/src/Service/Program.cs
@@ -1,0 +1,49 @@
+// ${{ .Inputs.description }}
+//
+// Serves three endpoints:
+//
+//   GET /         the service identity and release
+//   GET /healthz  liveness  — is the process alive
+//   GET /readyz   readiness — is the process ready to take traffic
+//
+// The liveness and readiness endpoints are what the Helm chart in charts/app
+// wires up as probes, so keep them cheap and dependency-free. A readiness check
+// that talks to a database takes the pod out of service the moment the database
+// hiccups, which is rarely what you want.
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Kestrel binds this rather than the default 5000, so the container listens
+// where the chart expects. PORT is set by the chart from the template's port.
+var port = Environment.GetEnvironmentVariable("PORT") ?? "${{ .Inputs.port }}";
+builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+// Set at build time by CI: the git tag for a release, the short SHA otherwise,
+// so a running pod can always be traced back to a commit.
+var release = Environment.GetEnvironmentVariable("RELEASE") ?? "dev";
+
+// BUCKET_NAME is set by the Helm chart from the storage component's output. The
+// workload reaches the bucket through its own cloud identity, so there are no
+// credentials to read here.
+var bucket = Environment.GetEnvironmentVariable("BUCKET_NAME") ?? string.Empty;
+
+app.MapGet("/healthz", () => Results.Ok(new { status = "ok" }));
+app.MapGet("/readyz", () => Results.Ok(new { status = "ok" }));
+
+app.MapGet("/", () => Results.Ok(new
+{
+    service = "${{ .Inputs.serviceName }}",
+    release,
+    bucket,
+}));
+
+app.Run();
+
+// Makes the entry point reachable from the test project's WebApplicationFactory.
+// A top-level-statements program generates an internal Program class, which the
+// test host cannot see without this.
+public partial class Program;

--- a/repo-templates/dotnet-app/skeleton/src/Service/Service.csproj
+++ b/repo-templates/dotnet-app/skeleton/src/Service/Service.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- A warning today is a bug tomorrow. Failing the build on one keeps the
+         generated repository honest from its first commit. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <RootNamespace>Service</RootNamespace>
+    <AssemblyName>Service</AssemblyName>
+    <!-- Lets the test project reach the minimal-API entry point through
+         WebApplicationFactory, which needs the generated Program class to be
+         visible outside its own assembly. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Service.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/repo-templates/dotnet-app/skeleton/tests/Service.Tests/EndpointTests.cs
+++ b/repo-templates/dotnet-app/skeleton/tests/Service.Tests/EndpointTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Service.Tests;
+
+public class EndpointTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Theory]
+    [InlineData("/healthz")]
+    [InlineData("/readyz")]
+    public async Task ProbesReportOk(string path)
+    {
+        var response = await _client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("ok", body.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task RootReportsTheServiceIdentity()
+    {
+        var response = await _client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("${{ .Inputs.serviceName }}", body.RootElement.GetProperty("service").GetString());
+        // Always reports something, even 'dev'.
+        Assert.False(string.IsNullOrEmpty(body.RootElement.GetProperty("release").GetString()));
+    }
+}

--- a/repo-templates/dotnet-app/skeleton/tests/Service.Tests/Service.Tests.csproj
+++ b/repo-templates/dotnet-app/skeleton/tests/Service.Tests/Service.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Service/Service.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/repo-templates/dotnet-app/wayfinder-template.yaml
+++ b/repo-templates/dotnet-app/wayfinder-template.yaml
@@ -1,0 +1,146 @@
+# Wayfinder repo template definition.
+#
+# Parsed strictly: an unrecognised key here is an error, not a warning.
+# Everything under skeleton/ is what gets written into the new repository.
+name: .NET service
+description: >-
+  A C# service on ASP.NET Core minimal APIs, targeting .NET 10, deployed by a
+  Wayfinder stack that runs the app on Kubernetes alongside an S3 bucket it
+  reaches through workload identity. Ships the standard Wayfinder CI set: pull
+  request previews, deploy to develop on merge, and deploy to production on a
+  tag.
+icon: dotnet
+
+inputs:
+  # The only required input. Everything else has a default so the template can
+  # be scaffolded from the catalogue, or from CI with --no-input, by supplying
+  # nothing but a name.
+  - name: serviceName
+    description: >-
+      Name of the service. Used for the Go command package, the container image,
+      the Helm release and the develop and production stack instance names.
+    type: string
+    minLength: 2
+    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+
+  - name: description
+    description: One line describing what this service does.
+    type: string
+    optional: true
+    defaultValue: "A .NET service scaffolded by Wayfinder"
+    maxLength: 200
+
+  - name: owner
+    description: Team that owns this service. Written into the README and CODEOWNERS.
+    type: string
+    optional: true
+    defaultValue: ""
+    maxLength: 60
+
+  # The scaffold context has no workspace, so CI needs to be told which one to
+  # deploy into. Leave blank to fall back to the WF_WORKSPACE GitHub variable,
+  # which is the better choice when one workspace serves many repositories.
+  - name: workspace
+    description: >-
+      Wayfinder workspace CI deploys into. Leave blank to take it from the
+      WF_WORKSPACE GitHub repository or organisation variable instead.
+    type: string
+    optional: true
+    defaultValue: ""
+    pattern: "^([a-z][a-z0-9-]*[a-z0-9])?$"
+
+  - name: developEnvironment
+    description: Environment deployed to on every merge to the default branch.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: prodEnvironment
+    description: Environment deployed to when a release tag is pushed.
+    type: string
+    optional: true
+    defaultValue: "prod"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: previewEnvironment
+    description: Environment pull request preview instances are created in.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: registry
+    description: Container registry the service image is published to.
+    type: string
+    optional: true
+    defaultValue: "ghcr.io"
+    enum: ["ghcr.io", "quay.io", "docker.io"]
+
+  - name: port
+    description: TCP port the service listens on.
+    type: number
+    optional: true
+    defaultValue: 8080
+    minimum: 1
+    maximum: 65535
+
+  - name: includeStorage
+    description: >-
+      Provision an S3 bucket alongside the service and grant the workload
+      read-write access to it through workload identity.
+    type: bool
+    optional: true
+    defaultValue: true
+
+  - name: storagePlan
+    description: >-
+      CloudResourcePlan backing the storage component. Defaults to the plan
+      bundled in the generated repository, so the stack deploys with no
+      catalogue prerequisite. Set it to a catalogue reference such as
+      aws-s3-data-bucket@1.0.0 to use your platform team's plan instead.
+    type: string
+    optional: true
+    defaultValue: "file:plans/aws-s3-data-bucket.yaml"
+
+  # Exposing the service needs a Gateway that already exists in the target
+  # environment, which only the platform team knows. With no gateway named, the
+  # service still deploys but is reachable only inside the cluster.
+  - name: gatewayName
+    description: >-
+      Name of an existing Gateway API Gateway to publish the service through.
+      Leave blank to deploy without an HTTPRoute, reachable in-cluster only.
+    type: string
+    optional: true
+    defaultValue: ""
+
+  - name: gatewayNamespace
+    description: >-
+      Namespace of the Gateway named in gatewayName. Leave blank when the
+      Gateway is in the same namespace as the service.
+    type: string
+    optional: true
+    defaultValue: ""
+
+skeleton:
+  path: skeleton
+
+  # Files listed here are copied byte for byte. Their contents are NOT rendered,
+  # so they must not use the `$${{ }}` escape either — it would land literally.
+  #
+  # Note that these globs are matched with path.Match: `**` is not supported, and
+  # `*.yaml` does not match `*.yml`, which is why both are listed.
+  raw:
+    # GitHub Actions has its own ${{ }} expression syntax. Keeping the workflows
+    # raw means they are valid Actions YAML exactly as written, both here and in
+    # the generated repository. Per-repository values reach them through
+    # .wayfinder/ci.env, which is rendered.
+    - ".github/workflows/*.yaml"
+    - ".github/workflows/*.yml"
+    - ".wayfinder/*.sh"
+    # Helm charts are Helm templating, evaluated at deploy time, not now.
+    - "charts/app/*"
+    - "charts/app/templates/*"
+    # CloudResourcePlans use the Wayfinder stack template engine, not this one.
+    - "plans/*.yaml"

--- a/repo-templates/go-app/README.md
+++ b/repo-templates/go-app/README.md
@@ -3,6 +3,10 @@
 A Go HTTP service on `net/http`, with a Wayfinder stack that runs it on
 Kubernetes alongside an S3 bucket it reaches through workload identity.
 
+`RepoTemplate-go-app.yaml` is the object you give Wayfinder — a pointer at this
+directory. `wayfinder-template.yaml` is the template itself, which Wayfinder
+reads once it has followed that pointer. See [../ANATOMY.md](../ANATOMY.md).
+
 This directory is the template definition. It is not itself a Go project — the
 project lives under `skeleton/`, and only that is written into a new repository.
 

--- a/repo-templates/go-app/README.md
+++ b/repo-templates/go-app/README.md
@@ -1,0 +1,69 @@
+# Go service template
+
+A Go HTTP service on `net/http`, with a Wayfinder stack that runs it on
+Kubernetes alongside an S3 bucket it reaches through workload identity.
+
+This directory is the template definition. It is not itself a Go project — the
+project lives under `skeleton/`, and only that is written into a new repository.
+
+| File | What it is |
+| --- | --- |
+| `wayfinder-template.yaml` | The template: its inputs, and which files are copied raw. |
+| `RepoTemplate-go-app.yaml` | Registers the template with Wayfinder. |
+| `skeleton/` | Everything written into the generated repository. |
+
+## Using it
+
+```bash
+wf apply -f RepoTemplate-go-app.yaml
+wf create stack payments --from-template go-app --input serviceName=payments --dry-run
+```
+
+Drop `--dry-run` and add `--github-org` and `--workspace` to create the
+repository for real. See [../DELIVERY-PIPELINE.md](../DELIVERY-PIPELINE.md) for what CI does and what it needs first.
+
+## What the generated repository contains
+
+```
+payments/
+├── README.md
+├── Wayfinder.yaml              app + S3 bucket, wired by workload identity
+├── Makefile                    test / lint / build — what CI calls
+├── Dockerfile                  distroless static, non-root
+├── go.mod
+├── cmd/payments/               main.go, main_test.go
+├── charts/app/                 the workload chart
+├── plans/                      the CloudResourcePlan for the bucket
+├── .wayfinder/                 ci.env (this repo's identity) + ci-env.sh
+└── .github/workflows/          ci · preview teardown · deploy develop · deploy prod
+```
+
+## Inputs
+
+`serviceName` is the only required one. It is used for the Go command package,
+the image name, the Helm release and the stack instance names.
+
+Everything else is optional and defaulted, so `--input serviceName=payments
+--no-input` is enough to scaffold from CI. The two worth setting deliberately:
+
+- `gatewayName` — name an existing Gateway API Gateway to publish the service.
+  Left blank, the service deploys but is reachable in-cluster only.
+- `workspace` — leave blank to take the workspace from the `WF_WORKSPACE`
+  GitHub variable instead, which is better when one workspace serves many
+  repositories.
+
+Run `wf get repotemplate go-app -o yaml` to see the full list with defaults.
+
+## Editing this template
+
+- **`skeleton/.github/workflows/*` and `skeleton/charts/**` are raw.** They are
+  copied byte for byte and never rendered, so they must not contain `${{ }}` or
+  `$${{ }}` meant for the scaffolder. Per-repository values belong in
+  `skeleton/.wayfinder/ci.env`, which is rendered.
+- **`skeleton/Wayfinder.yaml` is rendered and mixes two engines.** Every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` so it
+  survives scaffolding as a literal `${{ ... }}`. Getting this wrong fails at
+  the moment someone creates a repository, so check it with `--dry-run`.
+- The workflows are shared across all four templates in this repository. Edit
+  `../_shared/workflows/`, copy the result into every template, and CI will
+  check they match.

--- a/repo-templates/go-app/RepoTemplate-go-app.yaml
+++ b/repo-templates/go-app/RepoTemplate-go-app.yaml
@@ -1,0 +1,30 @@
+# Registers the Go service template with Wayfinder.
+#
+# This repository is public, so Wayfinder reads the template anonymously — no
+# GitHub connection is needed to register it or to preview what it renders.
+# Creating a repository from it does need a connected GitHub organisation.
+#
+#   wf apply -f RepoTemplate-go-app.yaml
+#   wf get repotemplate go-app -o yaml     # check status.manifest synced
+#   wf create stack payments --from-template go-app --input serviceName=payments --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: go-app
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: go
+    framework: net-http
+    family: wayfinder-golden-path
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/go-app
+  # Branch or tag to read. Pin this to a tag to hold the template steady —
+  # tracking a branch means every merge changes the template for everyone on the
+  # next resync. Point it at a branch to try a change before merging it.
+  ref: main
+  displayName: Go service
+  category: service

--- a/repo-templates/go-app/skeleton/.dockerignore
+++ b/repo-templates/go-app/skeleton/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.wayfinder
+bin
+charts
+plans
+coverage.out
+Wayfinder.yaml
+wayfinder-stack.yaml
+README.md

--- a/repo-templates/go-app/skeleton/.github/dependabot.yml
+++ b/repo-templates/go-app/skeleton/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps this repository current on its own, rather than relying on the template
+# it was scaffolded from being re-run.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/repo-templates/go-app/skeleton/.github/workflows/ci.yaml
+++ b/repo-templates/go-app/skeleton/.github/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/go-app/skeleton/.github/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/go-app/skeleton/.github/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/go-app/skeleton/.github/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/go-app/skeleton/.github/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/go-app/skeleton/.github/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/go-app/skeleton/.github/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/go-app/skeleton/.gitignore
+++ b/repo-templates/go-app/skeleton/.gitignore
@@ -1,0 +1,5 @@
+bin/
+coverage.out
+
+# Written by `wf up` to remember the stack instance you last deployed to.
+.wfup

--- a/repo-templates/go-app/skeleton/.wayfinder/ci-env.sh
+++ b/repo-templates/go-app/skeleton/.wayfinder/ci-env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Resolves the Wayfinder context for one CI stage and exports it to the job.
+#
+#   usage: .wayfinder/ci-env.sh <preview|develop|prod>
+#
+# Reads .wayfinder/ci.env, which Wayfinder wrote when this repository was
+# scaffolded, combines it with the WF_* GitHub variables set on the repository
+# or organisation, and writes the result to $GITHUB_ENV so later steps can use
+# it directly. Deployment target flags are written one per line to a file whose
+# path lands in WF_DEPLOY_ARGS_FILE; read them with `mapfile -t args < "$FILE"`.
+#
+# Exports:
+#   WAYFINDER_TENANT, WAYFINDER_WORKSPACE, WAYFINDER_ENVIRONMENT
+#   WAYFINDER_SERVICE_ACCOUNT  the CLI authenticates with this implicitly
+#   WF_INSTANCE                the stack instance for this stage
+#   WF_DEPLOY_ARGS_FILE        --target/--identity/--region/--dns-zone flags
+#   plus everything in .wayfinder/ci.env
+set -euo pipefail
+
+stage="${1:-}"
+if [[ -z "${stage}" ]]; then
+  echo "::error::usage: .wayfinder/ci-env.sh <preview|develop|prod>"
+  exit 1
+fi
+
+# shellcheck source=ci.env disable=SC1091
+source .wayfinder/ci.env
+
+case "${stage}" in
+  preview)
+    if [[ -z "${PR_NUMBER:-}" ]]; then
+      echo "::error::PR_NUMBER must be set for the preview stage."
+      exit 1
+    fi
+    environment="${WF_ENV_PREVIEW}"
+    account="${WF_SA_PREVIEW}"
+    instance="${WF_SERVICE_NAME}-pr${PR_NUMBER}"
+    ;;
+  develop)
+    environment="${WF_ENV_DEVELOP}"
+    account="${WF_SA_DEVELOP}"
+    instance="${WF_INSTANCE_DEVELOP}"
+    ;;
+  prod)
+    environment="${WF_ENV_PROD}"
+    account="${WF_SA_PROD}"
+    instance="${WF_INSTANCE_PROD}"
+    ;;
+  *)
+    echo "::error::Unknown stage '${stage}'. Expected preview, develop or prod."
+    exit 1
+    ;;
+esac
+
+# The workspace is a scaffold-time input. Where it was left blank, fall back to
+# the WF_WORKSPACE repository or organisation variable, which is the better
+# place for it when one workspace serves many repositories.
+workspace="${WF_WORKSPACE:-${WF_WORKSPACE_VAR:-}}"
+if [[ -z "${workspace}" ]]; then
+  echo "::error::No Wayfinder workspace. Set the WF_WORKSPACE repository or organisation variable."
+  exit 1
+fi
+
+args_file="${RUNNER_TEMP:-/tmp}/wf-deploy-args"
+: >"${args_file}"
+
+# A cluster in the workspace and environment already selected above, narrowed to
+# a namespace named after the instance so each deployment is isolated.
+if [[ -n "${WF_HOST_CLUSTER:-}" ]]; then
+  printf '%s\n' "--target" "k8s:${WF_HOST_CLUSTER}:${instance}" >>"${args_file}"
+fi
+# The cloud identity Wayfinder provisions cloud resources through. Wayfinder
+# reads the account it reaches, so no separate --target is needed for the cloud.
+if [[ -n "${WF_IDENTITY:-}" ]]; then
+  printf '%s\n' "--identity" "${WF_IDENTITY}" >>"${args_file}"
+fi
+if [[ -n "${WF_REGION:-}" ]]; then
+  printf '%s\n' "--region" "${WF_REGION}" >>"${args_file}"
+fi
+if [[ -n "${WF_DNS_ZONE:-}" ]]; then
+  printf '%s\n' "--dns-zone" "${WF_DNS_ZONE}" >>"${args_file}"
+fi
+
+{
+  # $GITHUB_ENV accepts KEY=value lines only, so the comments in ci.env are
+  # filtered out rather than passed through.
+  grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env
+  echo "WF_INSTANCE=${instance}"
+  echo "WF_DEPLOY_ARGS_FILE=${args_file}"
+  echo "WAYFINDER_TENANT=${WF_TENANT}"
+  echo "WAYFINDER_WORKSPACE=${workspace}"
+  echo "WAYFINDER_ENVIRONMENT=${environment}"
+  echo "WAYFINDER_SERVICE_ACCOUNT=${WF_TENANT}:${workspace}:${account}"
+} >>"${GITHUB_ENV:?GITHUB_ENV is not set; this script is meant to run in GitHub Actions}"
+
+echo "Stage ${stage}: instance ${instance} in ${WF_TENANT}:${workspace}:${environment}"
+echo "Deploying as service account ${WF_TENANT}:${workspace}:${account}"

--- a/repo-templates/go-app/skeleton/.wayfinder/ci.env
+++ b/repo-templates/go-app/skeleton/.wayfinder/ci.env
@@ -1,0 +1,36 @@
+# Wayfinder wrote this file when it created this repository.
+#
+# It holds the values that identify THIS repository to Wayfinder. Every CI job
+# loads it, so this is where to add a new per-repository value — the workflows
+# themselves are copied verbatim from the template and carry no repository
+# specifics.
+#
+# Values that differ per Wayfinder installation rather than per repository
+# (server URL, host cluster, cloud identity, DNS zone) are GitHub repository or
+# organisation variables instead. See .github/workflows/ and the template README.
+
+# Identity
+WF_SERVICE_NAME=${{ .Inputs.serviceName }}
+WF_TENANT=${{ .Tenant }}
+# Blank means "use the WF_WORKSPACE GitHub variable".
+WF_WORKSPACE=${{ .Inputs.workspace }}
+WF_APP_PORT=${{ .Inputs.port }}
+
+# Environments
+WF_ENV_PREVIEW=${{ .Inputs.previewEnvironment }}
+WF_ENV_DEVELOP=${{ .Inputs.developEnvironment }}
+WF_ENV_PROD=${{ .Inputs.prodEnvironment }}
+
+# Stack instances. Preview instances are named <service>-pr<number> at run time.
+WF_INSTANCE_DEVELOP=${{ .Inputs.serviceName }}-develop
+WF_INSTANCE_PROD=${{ .Inputs.serviceName }}-prod
+
+# Service accounts, one per environment, so a leaked preview credential cannot
+# deploy to production. Each is <tenant>:<workspace>:<name> at run time.
+WF_SA_PREVIEW=${{ .Inputs.serviceName }}-ci-preview
+WF_SA_DEVELOP=${{ .Inputs.serviceName }}-ci-develop
+WF_SA_PROD=${{ .Inputs.serviceName }}-ci-prod
+
+# Container image
+WF_IMAGE_REGISTRY=${{ .Inputs.registry }}
+WF_IMAGE_REPO=${{ .Inputs.registry }}/${{ .Repo.Organization }}/${{ .Repo.Name }}

--- a/repo-templates/go-app/skeleton/Dockerfile
+++ b/repo-templates/go-app/skeleton/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build -----------------------------------------------------------------
+FROM golang:1.25-alpine AS build
+
+WORKDIR /src
+
+# Dependencies first, so a source-only change reuses the cached module layer.
+COPY go.mod go.su[m] ./
+RUN go mod download
+
+COPY . .
+
+# VERSION is passed by CI: the git tag for a release, the short SHA otherwise.
+# It is compiled in so a running pod can report exactly what it is.
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build \
+      -ldflags "-s -w -X main.release=${VERSION}" \
+      -o /${{ .Inputs.serviceName }} \
+      ./cmd/${{ .Inputs.serviceName }}
+
+# ---- Run -------------------------------------------------------------------
+# Static distroless: no shell, no package manager, and a non-root user by
+# default. Nothing to exec into, which is the point.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /${{ .Inputs.serviceName }} /${{ .Inputs.serviceName }}
+
+USER nonroot:nonroot
+EXPOSE ${{ .Inputs.port }}
+
+ENTRYPOINT ["/${{ .Inputs.serviceName }}"]

--- a/repo-templates/go-app/skeleton/Makefile
+++ b/repo-templates/go-app/skeleton/Makefile
@@ -1,0 +1,45 @@
+# The CI workflows call `make test`, `make lint` and `make build` and nothing
+# else. That is deliberate: it keeps the workflows identical across every
+# Wayfinder service template, whatever the language. Change how this service is
+# built here, not in .github/workflows/.
+BINARY := ${{ .Inputs.serviceName }}
+RELEASE ?= dev
+
+.PHONY: all
+all: lint test build
+
+# Nothing to install: GitHub runners ship Go, and go.mod's `go 1.25` makes the
+# toolchain fetch the right version by itself.
+.PHONY: ci-setup
+ci-setup:
+	go version
+
+.PHONY: test
+test:
+	go test ./... -race -coverprofile=coverage.out -covermode=atomic
+
+.PHONY: lint
+lint:
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "These files need gofmt:"; echo "$$unformatted"; exit 1; \
+	fi
+	go vet ./...
+# For a stricter check, install golangci-lint and add:
+#	golangci-lint run
+
+.PHONY: build
+build:
+	CGO_ENABLED=0 go build -ldflags "-s -w -X main.release=$(RELEASE)" -o bin/$(BINARY) ./cmd/$(BINARY)
+
+.PHONY: run
+run:
+	go run ./cmd/$(BINARY)
+
+.PHONY: image
+image:
+	docker build --build-arg VERSION=$(RELEASE) -t $(BINARY):$(RELEASE) .
+
+.PHONY: clean
+clean:
+	rm -rf bin coverage.out

--- a/repo-templates/go-app/skeleton/README.md
+++ b/repo-templates/go-app/skeleton/README.md
@@ -1,0 +1,128 @@
+# ${{ .Inputs.serviceName }}
+
+${{ .Inputs.description }}
+
+Scaffolded by Wayfinder from the `go-app` template.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `cmd/${{ .Inputs.serviceName }}/` | The service. A `net/http` server with `/`, `/healthz` and `/readyz`. |
+| `Wayfinder.yaml` | The stack: what gets deployed and what it needs. |
+| `charts/app/` | The Helm chart for the workload. |
+| `plans/` | The CloudResourcePlan backing the storage component. |
+| `.wayfinder/ci.env` | This repository's Wayfinder identity, read by every CI job. |
+| `.github/workflows/` | Pull request previews, deploy to develop, deploy to production. |
+
+## Running it locally
+
+```bash
+make test     # go test with race detection and coverage
+make lint     # gofmt and go vet
+make run      # start the server on port ${{ .Inputs.port }}
+```
+
+```bash
+curl localhost:${{ .Inputs.port }}/healthz
+curl localhost:${{ .Inputs.port }}/
+```
+
+## Deploying it
+
+CI deploys this service for you. If you want to deploy a copy of your own from
+your laptop, into your own instance:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+wf down -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+```
+
+`wf up` needs an image to run, so pass one that already exists:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER --env-var IMAGE=<registry>/<org>/<repo>:<tag> --env-var RELEASE=local
+```
+
+## How CI works
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `${{ .Inputs.serviceName }}-pr<number>` is deployed in `${{ .Inputs.previewEnvironment }}` and its URL is commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | Tests run, an image tagged `sha-<short sha>` is built, and `${{ .Inputs.serviceName }}-develop` is deployed in `${{ .Inputs.developEnvironment }}`. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `${{ .Inputs.serviceName }}-prod` in `${{ .Inputs.prodEnvironment }}`. |
+
+Cutting a release is therefore:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Where CI configuration lives
+
+Nothing repository-specific is written into the workflow files — they are
+copied verbatim from the template so they stay upgradeable. Configuration
+splits in two:
+
+- **`.wayfinder/ci.env`** — values specific to this repository: the service
+  name, tenant, environments, service accounts and image repository. Add new
+  per-repository values here.
+- **GitHub repository or organisation variables** — values specific to your
+  Wayfinder installation, shared by every repository:
+
+  | Variable | What it is |
+  | --- | --- |
+  | `WF_SERVER` | Wayfinder API URL. |
+  | `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+  | `WF_WORKSPACE` | Workspace to deploy into, when `.wayfinder/ci.env` leaves it blank. |
+  | `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+  | `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+  | `WF_REGION` | Cloud region. |
+  | `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+  | `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides. Each falls back to the value above. |
+  | `WF_PROD_REQUIRE_APPROVAL` | Set to `true` to make production deploys pause for plan approval. |
+  | `WF_EXPECT_INSTANCE_ID` | Guards production against a misconfigured `WF_SERVER`. |
+
+### What CI needs before it can run
+
+Three Wayfinder service accounts, one per environment, each trusting a
+different GitHub OIDC subject so a preview credential cannot reach production:
+
+```bash
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-preview -w <workspace>
+wf create serviceaccountcredential github-preview \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-preview \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-pull-request
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-develop -w <workspace>
+wf create serviceaccountcredential github-develop \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-develop \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment develop
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-prod -w <workspace>
+wf create serviceaccountcredential github-prod \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-prod \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment production
+```
+
+Each needs the `deployer` role in its environment. The preview account also
+needs catalogue write, because `Wayfinder.yaml` refers to its plan as
+`file:plans/...`, which publishes that plan to the workspace catalogue — and
+that happens on a dry run too.
+
+You also need GitHub environments named `develop` and `production` (put your
+reviewers on `production`), and the cluster must be able to pull your image.
+Packages published to GHCR are private by default, so either make the package
+public or give the cluster an image pull secret.
+
+## Storage
+
+`Wayfinder.yaml` provisions an S3 bucket per stack instance and grants this
+service read-write access to it. The bucket name arrives as `BUCKET_NAME`.
+There are no credentials anywhere in this repository: the pod authenticates
+with its own cloud identity, which Wayfinder attaches to its Kubernetes service
+account.
+
+To drop the bucket, remove the `storage` component from `Wayfinder.yaml` along
+with the `workloadIdentity` block and the `env` entries that reference it.

--- a/repo-templates/go-app/skeleton/Wayfinder.yaml
+++ b/repo-templates/go-app/skeleton/Wayfinder.yaml
@@ -1,0 +1,87 @@
+# The Wayfinder stack for this service: what gets deployed, and what it needs.
+#
+# Two things here are filled in when you deploy, not when you edit:
+#
+#   $${{ ... }}  A Wayfinder stack expression. Component outputs, workload
+#               identity annotations and variables are resolved at deploy time.
+#   ${NAME}     Supplied by CI with `wf deploy --env-var NAME=value`. Every one
+#               must resolve, and an --env-var nothing references is rejected.
+#
+# Deploy it yourself with `wf up -i <instance>`; see `wf deploy --help`.
+apiVersion: v1
+name: ${{ .Stack.Name }}
+description: "${{ .Inputs.description }}"
+
+# Deploy-time settings you can vary per environment without editing this file:
+#   wf set var replicas --value 3 -w <workspace> -e prod
+# Values resolve down the tenant > workspace > environment > instance hierarchy.
+vars:
+  - name: replicas
+    description: Number of pods to run.
+    type: number
+    optional: true
+    defaultValue: 1
+
+components:
+${{- if .Inputs.includeStorage }}
+  # An S3 bucket for this service's data, created per stack instance — every
+  # preview, develop and production deployment gets its own.
+  #
+  # This is a provider component: it publishes consumption policies rather than
+  # credentials. The `app` component below is granted one of them, and Wayfinder
+  # turns that grant into the IAM policy on the workload's own identity. No
+  # access keys exist anywhere in this repository.
+  storage:
+    type: CloudResource
+    plan: ${{ .Inputs.storagePlan }}
+    inputs:
+      - name: suffix
+        value: data
+${{ end }}
+  app:
+    type: KubeResource
+${{- if .Inputs.gatewayName }}
+    outputs:
+      - name: url
+        description: Public URL of the service.
+        valueTemplate: "https://$${{ getDNSEntry }}"
+${{- end }}
+${{- if .Inputs.includeStorage }}
+    workloadIdentity:
+      serviceAccountName: ${{ .Inputs.serviceName }}
+      access:
+        - to: storage
+          consumptionPolicy: read-write
+${{- end }}
+    helm:
+      chartPath: charts/app
+      chartName: app
+      valuesTemplate: |
+        image: "${IMAGE}"
+        release: "${RELEASE}"
+        port: ${{ .Inputs.port }}
+        replicas: $${{ .Vars.replicas }}
+        serviceAccount:
+          name: ${{ .Inputs.serviceName }}
+${{- if .Inputs.includeStorage }}
+          annotations:
+        $${{ .WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+        env:
+          BUCKET_NAME: "$${{ .Components.storage.s3_bucket_id }}"
+          BUCKET_ARN: "$${{ .Components.storage.s3_bucket_arn }}"
+${{- end }}
+        httpRoute:
+${{- if .Inputs.gatewayName }}
+          enabled: true
+          hostname: "$${{ getDNSEntry }}"
+          parentGateway:
+            name: ${{ .Inputs.gatewayName }}
+${{- if .Inputs.gatewayNamespace }}
+            namespace: ${{ .Inputs.gatewayNamespace }}
+${{- end }}
+${{- else }}
+          # No Gateway was named when this repository was scaffolded, so the
+          # service is reachable inside the cluster only. To publish it, set
+          # httpRoute.enabled and name a Gateway that exists in this environment.
+          enabled: false
+${{- end }}

--- a/repo-templates/go-app/skeleton/charts/app/Chart.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: The workload for this service, deployed by the Wayfinder stack in Wayfinder.yaml.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/repo-templates/go-app/skeleton/charts/app/templates/_helpers.tpl
+++ b/repo-templates/go-app/skeleton/charts/app/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.serviceAccountName" -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.release | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/repo-templates/go-app/skeleton/charts/app/templates/deployment.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Rolls the pods when the release changes even if the image tag does not.
+        wayfinder.appvia.io/release: {{ .Values.release | quote }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ include "app.name" . }}
+          image: {{ required "image is required; it is supplied by CI as ${IMAGE}" .Values.image | quote }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: RELEASE
+              value: {{ .Values.release | quote }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/repo-templates/go-app/skeleton/charts/app/templates/httproute.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ required "httpRoute.parentGateway.name is required when httpRoute.enabled is true" .Values.httpRoute.parentGateway.name }}
+      {{- with .Values.httpRoute.parentGateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled is true" .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "app.fullname" . }}
+          port: {{ .Values.port }}
+{{- end }}

--- a/repo-templates/go-app/skeleton/charts/app/templates/service.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/repo-templates/go-app/skeleton/charts/app/templates/serviceaccount.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  # Wayfinder puts the cloud workload identity annotations here, which is how
+  # the pod authenticates to its cloud resources without any stored credentials.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/repo-templates/go-app/skeleton/charts/app/values.yaml
+++ b/repo-templates/go-app/skeleton/charts/app/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for a standalone `helm template`. In a real deployment every value
+# here is overwritten by the valuesTemplate in Wayfinder.yaml, which is where
+# the image tag, the workload identity annotations and the storage outputs come
+# from. Edit Wayfinder.yaml, not this file, unless you are adding a new value.
+
+# Container image reference. CI supplies this as ${IMAGE} at deploy time.
+image: ""
+
+# The release this is: a git tag, or sha-<short sha>.
+release: dev
+
+port: 8080
+replicas: 1
+
+serviceAccount:
+  name: app
+  # Wayfinder writes the cloud workload identity annotations here. That is what
+  # lets the pod reach its cloud resources with no credentials in the cluster.
+  annotations: {}
+
+# Environment variables for the container, as a plain name/value map.
+env: {}
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentGateway:
+    name: ""
+    # Leave blank when the Gateway is in this service's own namespace.
+    namespace: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/repo-templates/go-app/skeleton/cmd/${{ .Inputs.serviceName }}/main.go
+++ b/repo-templates/go-app/skeleton/cmd/${{ .Inputs.serviceName }}/main.go
@@ -1,0 +1,98 @@
+// Command ${{ .Inputs.serviceName }} is ${{ .Inputs.description }}
+//
+// It listens on PORT and serves three endpoints:
+//
+//	GET /         the service identity and release
+//	GET /healthz  liveness  — is the process alive
+//	GET /readyz   readiness — is the process ready to take traffic
+//
+// The liveness and readiness endpoints are what the Helm chart in charts/app
+// wires up as probes, so keep them cheap and dependency-free.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// release is set at build time with -ldflags "-X main.release=...". The CI
+// workflows pass the git tag for a release build and the short SHA otherwise,
+// so a running pod can always be traced back to a commit.
+var release = "dev"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "${{ .Inputs.port }}"
+	}
+
+	server := &http.Server{
+		Addr:              ":" + port,
+		Handler:           newRouter(logger),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// Shut down on SIGTERM so Kubernetes rolling updates drain in-flight
+	// requests instead of severing them.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		logger.Info("listening", "port", port, "release", release)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server stopped", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Info("shutting down")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Error("shutdown failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func newRouter(logger *slog.Logger) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, _ *http.Request) {
+		// BUCKET_NAME is set by the Helm chart from the storage component's
+		// output. The workload reaches the bucket through its own cloud
+		// identity, so there are no credentials to read here.
+		body := map[string]string{
+			"service": "${{ .Inputs.serviceName }}",
+			"release": release,
+			"bucket":  os.Getenv("BUCKET_NAME"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			logger.Error("writing response", "error", err)
+		}
+	})
+
+	return mux
+}

--- a/repo-templates/go-app/skeleton/cmd/${{ .Inputs.serviceName }}/main_test.go
+++ b/repo-templates/go-app/skeleton/cmd/${{ .Inputs.serviceName }}/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbesReportOK(t *testing.T) {
+	router := newRouter(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		t.Run(path, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("got status %d, want %d", recorder.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestRootReportsTheServiceIdentity(t *testing.T) {
+	router := newRouter(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	if got, want := body["service"], "${{ .Inputs.serviceName }}"; got != want {
+		t.Errorf("service = %q, want %q", got, want)
+	}
+	if body["release"] == "" {
+		t.Error("release is empty; it should always report something, even 'dev'")
+	}
+}

--- a/repo-templates/go-app/skeleton/go.mod
+++ b/repo-templates/go-app/skeleton/go.mod
@@ -1,0 +1,3 @@
+module github.com/${{ .Repo.Organization }}/${{ .Repo.Name }}
+
+go 1.25

--- a/repo-templates/go-app/skeleton/plans/aws-s3-data-bucket.yaml
+++ b/repo-templates/go-app/skeleton/plans/aws-s3-data-bucket.yaml
@@ -1,0 +1,144 @@
+apiVersion: cloudresources/v3
+kind: CloudResourcePlan
+metadata:
+  name: aws-s3-data-bucket
+  version: "1.0.0"
+spec:
+  cloud: aws
+  description: "S3 bucket for application data, with read-only / read-write / write-only consumption policies that other components can be granted."
+  inputs:
+    - name: versioning
+      description: "Enable object versioning. Use with caution — makes deletion harder."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: disable_force_destroy
+      description: "Disable force destroy. Use with caution — teardown will fail while objects remain."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: suffix
+      description: "Differentiates buckets within a stack instance. Combined with stack+instance to form the bucket prefix."
+      type: string
+      optional: true
+      defaultValue: "data"
+
+  # This is a PROVIDER plan: it has no workload identity of its own. Instead it
+  # publishes consumption policies that other components can be granted from the
+  # manifest. Wayfinder turns a grant into the IAM policy below and attaches it to
+  # the consumer's role — no IAM written by hand.
+  consumptionPolicies:
+    - name: read-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: read-write
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadWrite",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: write-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppWriteOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+
+  terraform:
+    modules:
+      - name: s3_bucket
+        source: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+        version: "v4.1.2"
+    files:
+      - name: main.tf
+        template: |
+          module "s3_bucket" {
+            source = ${{ .Modules.s3_bucket.Source | quote }}
+
+            bucket_prefix = "${{ .Stack.Name }}-${{ .Stack.Instance.Name }}-${{ .Inputs.suffix }}-"
+
+            ${{- if .Inputs.versioning }}
+            versioning = {
+              enabled = true
+            }
+            ${{- end }}
+
+            server_side_encryption_configuration = {
+              rule = {
+                apply_server_side_encryption_by_default = {
+                  sse_algorithm = "AES256"
+                }
+              }
+            }
+
+            # AWS blocks public access on new buckets by default; don't attach a
+            # public policy (and avoid s3:PutBucketPublicAccessBlock, which some
+            # account guardrails deny).
+            attach_public_policy = false
+
+            ${{- if not .Inputs.disable_force_destroy }}
+            force_destroy = true
+            ${{- end }}
+
+            tags = {
+              Application = "${{ .Stack.Name }}"
+              Environment = "${{ .Stack.Instance.Name }}"
+              ManagedBy   = "Wayfinder"
+            }
+          }
+      - name: outputs.tf
+        template: |
+          output "s3_bucket_arn" {
+            value = module.s3_bucket.s3_bucket_arn
+          }
+          output "s3_bucket_id" {
+            value = module.s3_bucket.s3_bucket_id
+          }

--- a/repo-templates/go-app/wayfinder-template.yaml
+++ b/repo-templates/go-app/wayfinder-template.yaml
@@ -1,0 +1,145 @@
+# Wayfinder repo template definition.
+#
+# Parsed strictly: an unrecognised key here is an error, not a warning.
+# Everything under skeleton/ is what gets written into the new repository.
+name: Go service
+description: >-
+  A Go HTTP service on net/http, deployed by a Wayfinder stack that runs the
+  app on Kubernetes alongside an S3 bucket it reaches through workload identity.
+  Ships the standard Wayfinder CI set: pull request previews, deploy to develop
+  on merge, and deploy to production on a tag.
+icon: go
+
+inputs:
+  # The only required input. Everything else has a default so the template can
+  # be scaffolded from the catalogue, or from CI with --no-input, by supplying
+  # nothing but a name.
+  - name: serviceName
+    description: >-
+      Name of the service. Used for the Go command package, the container image,
+      the Helm release and the develop and production stack instance names.
+    type: string
+    minLength: 2
+    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+
+  - name: description
+    description: One line describing what this service does.
+    type: string
+    optional: true
+    defaultValue: "A Go HTTP service scaffolded by Wayfinder"
+    maxLength: 200
+
+  - name: owner
+    description: Team that owns this service. Written into the README and CODEOWNERS.
+    type: string
+    optional: true
+    defaultValue: ""
+    maxLength: 60
+
+  # The scaffold context has no workspace, so CI needs to be told which one to
+  # deploy into. Leave blank to fall back to the WF_WORKSPACE GitHub variable,
+  # which is the better choice when one workspace serves many repositories.
+  - name: workspace
+    description: >-
+      Wayfinder workspace CI deploys into. Leave blank to take it from the
+      WF_WORKSPACE GitHub repository or organisation variable instead.
+    type: string
+    optional: true
+    defaultValue: ""
+    pattern: "^([a-z][a-z0-9-]*[a-z0-9])?$"
+
+  - name: developEnvironment
+    description: Environment deployed to on every merge to the default branch.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: prodEnvironment
+    description: Environment deployed to when a release tag is pushed.
+    type: string
+    optional: true
+    defaultValue: "prod"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: previewEnvironment
+    description: Environment pull request preview instances are created in.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: registry
+    description: Container registry the service image is published to.
+    type: string
+    optional: true
+    defaultValue: "ghcr.io"
+    enum: ["ghcr.io", "quay.io", "docker.io"]
+
+  - name: port
+    description: TCP port the service listens on.
+    type: number
+    optional: true
+    defaultValue: 8080
+    minimum: 1
+    maximum: 65535
+
+  - name: includeStorage
+    description: >-
+      Provision an S3 bucket alongside the service and grant the workload
+      read-write access to it through workload identity.
+    type: bool
+    optional: true
+    defaultValue: true
+
+  - name: storagePlan
+    description: >-
+      CloudResourcePlan backing the storage component. Defaults to the plan
+      bundled in the generated repository, so the stack deploys with no
+      catalogue prerequisite. Set it to a catalogue reference such as
+      aws-s3-data-bucket@1.0.0 to use your platform team's plan instead.
+    type: string
+    optional: true
+    defaultValue: "file:plans/aws-s3-data-bucket.yaml"
+
+  # Exposing the service needs a Gateway that already exists in the target
+  # environment, which only the platform team knows. With no gateway named, the
+  # service still deploys but is reachable only inside the cluster.
+  - name: gatewayName
+    description: >-
+      Name of an existing Gateway API Gateway to publish the service through.
+      Leave blank to deploy without an HTTPRoute, reachable in-cluster only.
+    type: string
+    optional: true
+    defaultValue: ""
+
+  - name: gatewayNamespace
+    description: >-
+      Namespace of the Gateway named in gatewayName. Leave blank when the
+      Gateway is in the same namespace as the service.
+    type: string
+    optional: true
+    defaultValue: ""
+
+skeleton:
+  path: skeleton
+
+  # Files listed here are copied byte for byte. Their contents are NOT rendered,
+  # so they must not use the `$${{ }}` escape either — it would land literally.
+  #
+  # Note that these globs are matched with path.Match: `**` is not supported, and
+  # `*.yaml` does not match `*.yml`, which is why both are listed.
+  raw:
+    # GitHub Actions has its own ${{ }} expression syntax. Keeping the workflows
+    # raw means they are valid Actions YAML exactly as written, both here and in
+    # the generated repository. Per-repository values reach them through
+    # .wayfinder/ci.env, which is rendered.
+    - ".github/workflows/*.yaml"
+    - ".github/workflows/*.yml"
+    - ".wayfinder/*.sh"
+    # Helm charts are Helm templating, evaluated at deploy time, not now.
+    - "charts/app/*"
+    - "charts/app/templates/*"
+    # CloudResourcePlans use the Wayfinder stack template engine, not this one.
+    - "plans/*.yaml"

--- a/repo-templates/go-library/README.md
+++ b/repo-templates/go-library/README.md
@@ -1,0 +1,36 @@
+# Go library template
+
+A Go module with tests and CI, for shared code rather than a deployable service.
+
+Register it:
+
+```bash
+wf apply -f repo-templates/go-library/RepoTemplate-go-library.yaml
+```
+
+`RepoTemplate-go-library.yaml` is the object you give Wayfinder — a pointer at
+this directory. `wayfinder-template.yaml` is the template itself, which
+Wayfinder reads once it has followed that pointer. Neither is scaffolded; only
+`skeleton/` is. See [../ANATOMY.md](../ANATOMY.md).
+
+## Inputs
+
+| Input | Type | Required | Default | Notes |
+| ----- | ---- | -------- | ------- | ----- |
+| `packageName` | string | yes | — | `^[a-z][a-z0-9]*$`. Used for the directory and the package clause |
+
+## What the skeleton exercises
+
+The smallest useful template: one input, a handful of files, and no deployment
+at all.
+
+- **No `Wayfinder.yaml`** — not everything scaffolded is a deployable service. A
+  library is never deployed, so it declares no stack, and `wf up` has nothing to
+  do with it. The template still saves the setup.
+- **Templated path** — `${{ .Inputs.packageName }}/` becomes the package
+  directory.
+- **`$${{` escaping** — the CI workflow escapes GitHub Actions' expressions so
+  they survive rendering, including a build matrix over two Go versions.
+
+Because it deploys nothing, this is also the quickest template to try end to
+end: nothing needs a cloud account, a cluster or a plan.

--- a/repo-templates/go-library/RepoTemplate-go-library.yaml
+++ b/repo-templates/go-library/RepoTemplate-go-library.yaml
@@ -1,0 +1,31 @@
+# A Go module with tests and CI, for shared code rather than a deployable service.
+#
+# This is the object you give Wayfinder. It is a POINTER: it says which
+# repository, which branch or tag, and which directory inside it. The template
+# itself — its name, inputs and files — is `wayfinder-template.yaml` at that
+# path, which Wayfinder reads once it has followed this. See ../ANATOMY.md.
+#
+#   wf apply -f RepoTemplate-go-library.yaml
+#   wf get repotemplate go-library -o yaml      # check status.manifest synced
+#   wf create stack demo --from-template go-library --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: go-library
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: go
+    framework: none
+    family: wayfinder-example
+spec:
+  # Public repository, so Wayfinder clones it anonymously — registering needs no
+  # GitHub connection. Creating a repository from it does.
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/go-library
+  # Branch or tag to read. Pin this to a tag to hold the template steady.
+  ref: main
+  displayName: Go library
+  category: library

--- a/repo-templates/go-microservice/README.md
+++ b/repo-templates/go-microservice/README.md
@@ -3,7 +3,13 @@
 The worked example the Wayfinder documentation walks through file by file in
 [Example Template Repository](https://on.wayfinder.run/docs/repo-templates/04-example-template-repository).
 
-Register it with `--path repo-templates/go-microservice`:
+Register it:
+
+```bash
+wf apply -f repo-templates/go-microservice/RepoTemplate-go-microservice.yaml
+```
+
+or imperatively, which does the same thing:
 
 ```bash
 wf create repotemplate go-microservice \
@@ -12,8 +18,10 @@ wf create repotemplate go-microservice \
   --category service --label language:go
 ```
 
-This file and `wayfinder-template.yaml` are **not** scaffolded — only
-`skeleton/` is.
+`RepoTemplate-go-microservice.yaml` is the object you give Wayfinder — a pointer
+at this directory. `wayfinder-template.yaml` is the template itself, which
+Wayfinder reads once it has followed that pointer. Neither is scaffolded; only
+`skeleton/` is. See [../ANATOMY.md](../ANATOMY.md).
 
 ## Inputs
 

--- a/repo-templates/go-microservice/RepoTemplate-go-microservice.yaml
+++ b/repo-templates/go-microservice/RepoTemplate-go-microservice.yaml
@@ -1,0 +1,31 @@
+# A minimal Go service — the worked example the documentation walks through.
+#
+# This is the object you give Wayfinder. It is a POINTER: it says which
+# repository, which branch or tag, and which directory inside it. The template
+# itself — its name, inputs and files — is `wayfinder-template.yaml` at that
+# path, which Wayfinder reads once it has followed this. See ../ANATOMY.md.
+#
+#   wf apply -f RepoTemplate-go-microservice.yaml
+#   wf get repotemplate go-microservice -o yaml      # check status.manifest synced
+#   wf create stack demo --from-template go-microservice --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: go-microservice
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: go
+    framework: net-http
+    family: wayfinder-example
+spec:
+  # Public repository, so Wayfinder clones it anonymously — registering needs no
+  # GitHub connection. Creating a repository from it does.
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/go-microservice
+  # Branch or tag to read. Pin this to a tag to hold the template steady.
+  ref: main
+  displayName: Go microservice
+  category: service

--- a/repo-templates/go-service/README.md
+++ b/repo-templates/go-service/README.md
@@ -1,0 +1,50 @@
+# Go service with Helm chart template
+
+A Go HTTP service that ships its own Helm chart and a deployable
+`Wayfinder.yaml`, so the repository it creates can be deployed without anything
+else being published first.
+
+Register it:
+
+```bash
+wf apply -f repo-templates/go-service/RepoTemplate-go-service.yaml
+```
+
+`RepoTemplate-go-service.yaml` is the object you give Wayfinder — a pointer at
+this directory. `wayfinder-template.yaml` is the template itself, which
+Wayfinder reads once it has followed that pointer. Neither is scaffolded; only
+`skeleton/` is. See [../ANATOMY.md](../ANATOMY.md).
+
+## Inputs
+
+| Input | Type | Required | Default | Notes |
+| ----- | ---- | -------- | ------- | ----- |
+| `serviceName` | string | yes | — | `^[a-z][a-z0-9]{1,19}$`, 2–20 chars |
+| `summary` | string | no | — | One line, used in the README and the stack description |
+| `goVersion` | string | no | `1.25` | One of `1.24`, `1.25` |
+| `port` | number | no | `8080` | 1024–65535 |
+| `replicas` | number | no | `2` | 1–10 |
+| `includeDocs` | bool | no | `false` | When `true`, a `docs/` directory is generated |
+
+## What the skeleton exercises
+
+- **`$${{` escaping** — the CI workflow keeps GitHub Actions' own `${{ }}`
+  expressions by escaping each one, rather than exempting the whole file. That
+  leaves the rest of the workflow templatable, so the Go version and the service
+  name are filled in for you. Contrast
+  [`../go-microservice`](../go-microservice), which uses a `raw` glob instead.
+- **A chart deployed with `chartPath`** — `Wayfinder.yaml` points at
+  `./charts/app` in the same repository, so there is no chart to publish
+  anywhere first.
+- **Templated path** — `cmd/${{ .Inputs.serviceName }}/main.go`.
+- **Conditional inclusion** — the condition wraps the whole path, so it can
+  render to nothing and leave the file out.
+
+## Deploying what it scaffolds
+
+The generated `Wayfinder.yaml` deploys the chart and takes its image from
+`${image}`, resolved by `wf up` from your shell or CI environment:
+
+```bash
+image=ghcr.io/your-org/your-repo:latest wf up
+```

--- a/repo-templates/go-service/RepoTemplate-go-service.yaml
+++ b/repo-templates/go-service/RepoTemplate-go-service.yaml
@@ -1,0 +1,31 @@
+# A Go HTTP service with its own Helm chart and a deployable Wayfinder.yaml.
+#
+# This is the object you give Wayfinder. It is a POINTER: it says which
+# repository, which branch or tag, and which directory inside it. The template
+# itself — its name, inputs and files — is `wayfinder-template.yaml` at that
+# path, which Wayfinder reads once it has followed this. See ../ANATOMY.md.
+#
+#   wf apply -f RepoTemplate-go-service.yaml
+#   wf get repotemplate go-service -o yaml      # check status.manifest synced
+#   wf create stack demo --from-template go-service --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: go-service
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: go
+    framework: net-http
+    family: wayfinder-example
+spec:
+  # Public repository, so Wayfinder clones it anonymously — registering needs no
+  # GitHub connection. Creating a repository from it does.
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/go-service
+  # Branch or tag to read. Pin this to a tag to hold the template steady.
+  ref: main
+  displayName: Go service with Helm chart
+  category: service

--- a/repo-templates/go-service/wayfinder-template.yaml
+++ b/repo-templates/go-service/wayfinder-template.yaml
@@ -1,4 +1,4 @@
-name: Go microservice
+name: Go service with Helm chart
 description: A Go HTTP service with its own Helm chart, a CI pipeline and a deployable Wayfinder.yaml
 icon: go
 

--- a/repo-templates/hack/.gitignore
+++ b/repo-templates/hack/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/repo-templates/hack/check-templates.py
+++ b/repo-templates/hack/check-templates.py
@@ -15,7 +15,7 @@ Two groups of checks:
                    respects the fetch limits, and leaves no foreign ${{ }}
                    expression bare in a file Wayfinder will render.
 
-  the pipeline set the go-app / python-app / node-app family, which share one CI
+  the pipeline set the *-app family (go, python, node, java, dotnet), which share one CI
                    contract and one inputs contract. Mark's go-service,
                    go-microservice and go-library deliberately differ from each
                    other — they exist to demonstrate different mechanics — so the
@@ -37,7 +37,7 @@ MAX_FILE_SIZE = 1024 * 1024
 MAX_FILES = 2000
 
 # Templates that share the CI and inputs contract.
-PIPELINE_TEMPLATES = ["go-app", "python-app", "node-app"]
+PIPELINE_TEMPLATES = ["go-app", "python-app", "node-app", "java-app", "dotnet-app"]
 
 # The inputs every template in the pipeline family declares, in this order.
 SHARED_INPUTS = [

--- a/repo-templates/hack/check-templates.py
+++ b/repo-templates/hack/check-templates.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Structural checks for the repo templates.
+
+Everything here can be answered without a Wayfinder server: it checks the things
+that are true of a template by construction. The parts that need the real
+template engine — that a skeleton renders at all, and that Wayfinder.yaml comes
+out as a readable stack — are covered by the render test in the wayfinder
+repository and by `wf create stack --dry-run`.
+
+    usage: repo-templates/hack/check-templates.py [repo-templates-dir]
+
+Two groups of checks:
+
+  every template   manifest parses, ships a README, ships no wayfinder-stack.yaml,
+                   respects the fetch limits, and leaves no foreign ${{ }}
+                   expression bare in a file Wayfinder will render.
+
+  the pipeline set the go-app / python-app / node-app family, which share one CI
+                   contract and one inputs contract. Mark's go-service,
+                   go-microservice and go-library deliberately differ from each
+                   other — they exist to demonstrate different mechanics — so the
+                   family checks do not apply to them.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import pathlib
+import sys
+
+import yaml
+
+# Wayfinder refuses a template tree that exceeds these.
+MAX_FILE_SIZE = 1024 * 1024
+MAX_FILES = 2000
+
+# Templates that share the CI and inputs contract.
+PIPELINE_TEMPLATES = ["go-app", "python-app", "node-app"]
+
+# The inputs every template in the pipeline family declares, in this order.
+SHARED_INPUTS = [
+    "serviceName",
+    "description",
+    "owner",
+    "workspace",
+    "developEnvironment",
+    "prodEnvironment",
+    "previewEnvironment",
+    "registry",
+    "port",
+    "includeStorage",
+    "storagePlan",
+    "gatewayName",
+    "gatewayNamespace",
+]
+
+# Files whose ${{ }} expressions are not all Wayfinder's. A GitHub Actions
+# workflow, a Helm chart and a CloudResourcePlan each have their own templating
+# in the same delimiters, and there are two valid ways to protect it: exempt the
+# file with a skeleton.raw glob, or escape each foreign expression as `$${{`.
+# Both are in use here deliberately. What is never valid is leaving a foreign
+# expression bare in a rendered file — Wayfinder evaluates it at scaffold time
+# and either fails outright or silently eats it.
+def has_foreign_expressions(rel: str) -> bool:
+    return (
+        rel.startswith(".github/")
+        or rel.startswith("charts/")
+        or rel.startswith("plans/")
+        or rel.endswith(".sh")
+    )
+
+
+# The whole render context. Anything else inside a bare ${{ }} belongs to
+# something other than the scaffolder.
+SCAFFOLD_ROOTS = (".Inputs", ".Repo", ".Stack", ".Tenant")
+
+# Control structures and pipeline helpers, which carry no context of their own.
+SCAFFOLD_KEYWORDS = ("if", "end", "else", "range", "with", "define", "template", "block")
+
+# A ${{ ... }} not already escaped as $${{ ... }}.
+BARE_EXPRESSION = re.compile(r"(?<!\$)\$\{\{(.*?)\}\}", re.DOTALL)
+
+
+def foreign_expressions(content: str) -> list[str]:
+    """Bare ${{ }} expressions that the scaffolder cannot resolve."""
+    found = []
+    for expression in BARE_EXPRESSION.findall(content):
+        body = expression.strip().lstrip("-").strip()
+        if not body:
+            continue
+        first = body.split()[0].lstrip("-")
+        if first in SCAFFOLD_KEYWORDS:
+            continue
+        # A reference the scaffolder owns, anywhere in the expression, makes it
+        # a scaffold expression — `.Inputs.x | default "y"` is still ours.
+        if any(root in body for root in SCAFFOLD_ROOTS):
+            continue
+        found.append(body)
+    return found
+
+
+class Failures:
+    def __init__(self) -> None:
+        self.items: list[str] = []
+
+    def add(self, where: str, message: str) -> None:
+        self.items.append(f"{where}: {message}")
+        # GitHub renders this as an annotation on the run.
+        print(f"::error file={where}::{message}")
+
+    def ok(self) -> bool:
+        return not self.items
+
+
+def matches_raw(globs: list[str], rel: str) -> bool:
+    # Wayfinder matches these with Go's path.Match: no `**`, and a `*` never
+    # crosses a `/`. fnmatch's `*` DOES cross `/`, so compare segment counts too
+    # or this check would pass globs Wayfinder will not honour.
+    for pattern in globs:
+        if pattern.count("/") != rel.count("/"):
+            continue
+        if fnmatch.fnmatchcase(rel, pattern):
+            return True
+    return False
+
+
+def skeleton_files(skeleton: pathlib.Path) -> list[tuple[str, pathlib.Path]]:
+    found = []
+    for dirpath, _, filenames in os.walk(skeleton):
+        for filename in filenames:
+            path = pathlib.Path(dirpath) / filename
+            found.append((str(path.relative_to(skeleton)), path))
+    return sorted(found)
+
+
+def check_template(root: pathlib.Path, name: str, fail: Failures) -> dict | None:
+    directory = root / name
+    manifest_path = directory / "wayfinder-template.yaml"
+    where = f"repo-templates/{name}/wayfinder-template.yaml"
+
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text())
+    except FileNotFoundError:
+        fail.add(where, "no wayfinder-template.yaml")
+        return None
+    except yaml.YAMLError as err:
+        fail.add(where, f"is not valid YAML: {err}")
+        return None
+
+    if not manifest.get("name"):
+        fail.add(where, "declares no name")
+
+    skeleton_dir = manifest.get("skeleton", {}).get("path", "skeleton")
+    skeleton = directory / skeleton_dir
+    if not skeleton.is_dir():
+        fail.add(where, f"skeleton.path {skeleton_dir!r} is not a directory")
+        return manifest
+
+    raw_globs = manifest.get("skeleton", {}).get("raw", []) or []
+    files = skeleton_files(skeleton)
+
+    if len(files) > MAX_FILES:
+        fail.add(where, f"{len(files)} files, more than the {MAX_FILES} Wayfinder will fetch")
+
+    has_readme = False
+    for rel, path in files:
+        location = f"repo-templates/{name}/{skeleton_dir}/{rel}"
+
+        if path.is_symlink():
+            fail.add(location, "is a symlink; Wayfinder skips those, so it would silently vanish")
+            continue
+
+        size = path.stat().st_size
+        if size > MAX_FILE_SIZE:
+            fail.add(location, f"is {size} bytes, over the {MAX_FILE_SIZE} byte limit")
+
+        if rel == "README.md":
+            has_readme = True
+        if rel == "wayfinder-stack.yaml":
+            fail.add(location, "is written by Wayfinder at scaffold time; shipping one gets it overwritten")
+
+        is_raw = matches_raw(raw_globs, rel)
+        try:
+            content = path.read_text()
+        except UnicodeDecodeError:
+            continue  # binary, passed through whichever way
+
+        if is_raw:
+            if "$${{" in content:
+                fail.add(location, "is raw, so `$${{` is not an escape here — it lands literally")
+        elif has_foreign_expressions(rel):
+            for expression in foreign_expressions(content):
+                fail.add(
+                    location,
+                    f"is rendered, but `${{{{ {expression} }}}}` is not a scaffold expression. "
+                    "Escape it as `$${{ ... }}`, or exempt the file with a skeleton.raw glob "
+                    "(path.Match has no `**`, and `*.yaml` does not match `*.yml`)",
+                )
+
+    if not has_readme:
+        fail.add(
+            f"repo-templates/{name}/{skeleton_dir}",
+            "ships no README.md, so the repository Wayfinder creates would have none "
+            "(the auto-init stub is deleted)",
+        )
+
+    return manifest
+
+
+def check_pipeline_family(root: pathlib.Path, manifests: dict[str, dict], fail: Failures) -> None:
+    shared = root / "_shared" / "workflows"
+    if not shared.is_dir():
+        fail.add("repo-templates/_shared/workflows", "does not exist")
+        return
+
+    for workflow in sorted(shared.iterdir()):
+        want = workflow.read_bytes()
+        for name in PIPELINE_TEMPLATES:
+            copy = root / name / "skeleton" / ".github" / "workflows" / workflow.name
+            location = f"repo-templates/{name}/skeleton/.github/workflows/{workflow.name}"
+            if not copy.exists():
+                fail.add(location, f"is missing; copy it from _shared/workflows/{workflow.name}")
+            elif copy.read_bytes() != want:
+                fail.add(location, f"has drifted from _shared/workflows/{workflow.name}; copy the shared file over it")
+
+    for name in PIPELINE_TEMPLATES:
+        manifest = manifests.get(name)
+        if not manifest:
+            continue
+        declared = [i.get("name") for i in manifest.get("inputs", []) or []]
+        where = f"repo-templates/{name}/wayfinder-template.yaml"
+        missing = [i for i in SHARED_INPUTS if i not in declared]
+        if missing:
+            fail.add(where, f"is missing shared inputs: {', '.join(missing)}")
+        for definition in manifest.get("inputs", []) or []:
+            if definition.get("name") != "serviceName":
+                continue
+            if definition.get("optional"):
+                fail.add(where, "serviceName must be required")
+        for definition in manifest.get("inputs", []) or []:
+            n = definition.get("name")
+            if n in SHARED_INPUTS and n != "serviceName":
+                if not definition.get("optional"):
+                    fail.add(where, f"input {n!r} must be optional, or a --no-input scaffold cannot work")
+                elif "defaultValue" not in definition:
+                    fail.add(where, f"input {n!r} is optional but declares no default")
+
+
+def check_registrations(root: pathlib.Path, fail: Failures) -> None:
+    for registration in sorted(root.glob("*/RepoTemplate-*.yaml")):
+        where = str(registration.relative_to(root.parent))
+        try:
+            doc = yaml.safe_load(registration.read_text())
+        except yaml.YAMLError as err:
+            fail.add(where, f"is not valid YAML: {err}")
+            continue
+        spec = doc.get("spec", {})
+        path = spec.get("path")
+        if not path:
+            fail.add(where, "declares no spec.path")
+            continue
+        target = root.parent / path / "wayfinder-template.yaml"
+        if not target.exists():
+            fail.add(where, f"spec.path {path!r} has no wayfinder-template.yaml")
+        expected = f"repo-templates/{registration.parent.name}"
+        if path != expected:
+            fail.add(where, f"spec.path is {path!r} but the file lives in {expected!r}")
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "repo-templates")
+    if not root.is_dir():
+        print(f"no such directory: {root}", file=sys.stderr)
+        return 2
+
+    fail = Failures()
+    manifests: dict[str, dict] = {}
+
+    for directory in sorted(root.iterdir()):
+        if not directory.is_dir() or directory.name.startswith("_") or directory.name == "hack":
+            continue
+        manifest = check_template(root, directory.name, fail)
+        if manifest:
+            manifests[directory.name] = manifest
+
+    check_pipeline_family(root, manifests, fail)
+    check_registrations(root, fail)
+
+    if not fail.ok():
+        print(f"\n{len(fail.items)} problem(s) found.", file=sys.stderr)
+        return 1
+
+    print(f"Checked {len(manifests)} templates: all good.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/repo-templates/hack/render-for-build.sh
+++ b/repo-templates/hack/render-for-build.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Renders a template's skeleton with placeholder values so CI can compile it.
+#
+#   usage: repo-templates/hack/render-for-build.sh <template-dir> <output-dir>
+#
+# This is deliberately NOT a faithful implementation of Wayfinder's template
+# engine. It substitutes the simple `${{ .Inputs.x }}` style references and
+# renames templated directories, which is all that is needed to answer "does
+# this skeleton actually build and pass its own tests". Conditionals appear only
+# in Wayfinder.yaml, which is excluded here and checked properly by the render
+# test in the wayfinder repository and by `wf create stack --dry-run`.
+set -euo pipefail
+
+template_dir="${1:?usage: render-for-build.sh <template-dir> <output-dir>}"
+out_dir="${2:?usage: render-for-build.sh <template-dir> <output-dir>}"
+
+skeleton="${template_dir}/skeleton"
+if [[ ! -d "${skeleton}" ]]; then
+  echo "no skeleton in ${template_dir}" >&2
+  exit 1
+fi
+
+rm -rf "${out_dir}"
+mkdir -p "${out_dir}"
+cp -R "${skeleton}/." "${out_dir}/"
+
+# Wayfinder.yaml uses conditionals this script does not implement, and nothing
+# in a language build reads it.
+rm -f "${out_dir}/Wayfinder.yaml"
+
+python3 - "${out_dir}" <<'PYTHON'
+import os
+import re
+import sys
+
+root = sys.argv[1]
+
+# Placeholder values. Chosen to be valid everywhere: a Go package name, a Java
+# artifact id, a Python module and an npm package name all accept these.
+VALUES = {
+    ".Inputs.serviceName": "example",
+    ".Inputs.description": "An example service",
+    ".Inputs.owner": "example-team",
+    ".Inputs.workspace": "example-workspace",
+    ".Inputs.developEnvironment": "dev",
+    ".Inputs.prodEnvironment": "prod",
+    ".Inputs.previewEnvironment": "dev",
+    ".Inputs.registry": "ghcr.io",
+    ".Inputs.port": "8080",
+    ".Inputs.includeStorage": "true",
+    ".Inputs.storagePlan": "file:plans/aws-s3-data-bucket.yaml",
+    ".Inputs.gatewayName": "",
+    ".Inputs.gatewayNamespace": "",
+    ".Inputs.groupId": "com.example",
+    ".Inputs.groupPath": "com/example",
+    ".Repo.Organization": "example-org",
+    ".Repo.Name": "example-service",
+    ".Repo.URL": "https://github.com/example-org/example-service",
+    ".Repo.DefaultBranch": "main",
+    ".Stack.Name": "example",
+    ".Tenant": "example-tenant",
+}
+
+EXPRESSION = re.compile(r"\$\{\{-?\s*(\.[A-Za-z0-9_.]+)\s*-?\}\}")
+
+# Files copied verbatim by the real engine. Substituting in them here would be
+# wrong, and in the workflows it would eat GitHub Actions' own expressions.
+def is_raw(rel):
+    return (
+        rel.startswith(".github/workflows/")
+        or rel.startswith("charts/")
+        or rel.startswith("plans/")
+        or rel.endswith(".sh")
+    )
+
+
+def substitute(text):
+    def replace(match):
+        key = match.group(1)
+        if key not in VALUES:
+            raise SystemExit(f"render-for-build.sh does not know {key}; add it to VALUES")
+        return VALUES[key]
+
+    return EXPRESSION.sub(replace, text)
+
+
+# Contents first.
+for dirpath, _, filenames in os.walk(root):
+    for filename in filenames:
+        path = os.path.join(dirpath, filename)
+        rel = os.path.relpath(path, root)
+        if is_raw(rel):
+            continue
+        try:
+            with open(path, encoding="utf-8") as handle:
+                original = handle.read()
+        except UnicodeDecodeError:
+            continue  # binary, passed through
+        rendered = substitute(original)
+        if rendered != original:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(rendered)
+
+# Then paths, deepest first so renaming a parent cannot invalidate a child path.
+for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+    for name in filenames + dirnames:
+        if "${{" not in name:
+            continue
+        os.rename(os.path.join(dirpath, name), os.path.join(dirpath, substitute(name)))
+PYTHON
+
+echo "Rendered ${template_dir} into ${out_dir}"

--- a/repo-templates/hack/render-for-build.sh
+++ b/repo-templates/hack/render-for-build.sh
@@ -29,31 +29,27 @@ cp -R "${skeleton}/." "${out_dir}/"
 # in a language build reads it.
 rm -f "${out_dir}/Wayfinder.yaml"
 
-python3 - "${out_dir}" <<'PYTHON'
+python3 - "${out_dir}" "${template_dir}/wayfinder-template.yaml" <<'PYTHON'
+import fnmatch
 import os
 import re
 import sys
 
-root = sys.argv[1]
+import yaml
 
-# Placeholder values. Chosen to be valid everywhere: a Go package name, a Java
-# artifact id, a Python module and an npm package name all accept these.
-VALUES = {
-    ".Inputs.serviceName": "example",
-    ".Inputs.description": "An example service",
-    ".Inputs.owner": "example-team",
-    ".Inputs.workspace": "example-workspace",
-    ".Inputs.developEnvironment": "dev",
-    ".Inputs.prodEnvironment": "prod",
-    ".Inputs.previewEnvironment": "dev",
-    ".Inputs.registry": "ghcr.io",
-    ".Inputs.port": "8080",
-    ".Inputs.includeStorage": "true",
-    ".Inputs.storagePlan": "file:plans/aws-s3-data-bucket.yaml",
-    ".Inputs.gatewayName": "",
-    ".Inputs.gatewayNamespace": "",
-    ".Inputs.groupId": "com.example",
-    ".Inputs.groupPath": "com/example",
+root = sys.argv[1]
+MANIFEST = sys.argv[2]
+
+# Placeholder values for the render context.
+#
+# Input values come from the manifest itself — its declared default where there
+# is one, otherwise something type-appropriate — so a template that adds an
+# input does not have to be registered here as well. NAME_LIKE covers the inputs
+# whose value ends up in a path or an identifier, where "example" is safe and a
+# generic placeholder might not be.
+NAME_LIKE = {"serviceName", "packageName", "name", "appName", "moduleName"}
+
+CONTEXT = {
     ".Repo.Organization": "example-org",
     ".Repo.Name": "example-service",
     ".Repo.URL": "https://github.com/example-org/example-service",
@@ -62,24 +58,69 @@ VALUES = {
     ".Tenant": "example-tenant",
 }
 
+
+def placeholder(definition):
+    """A usable value for one declared input."""
+    name = definition.get("name", "")
+    if name in NAME_LIKE:
+        return "example"
+    if "defaultValue" in definition:
+        value = definition["defaultValue"]
+        return "true" if value is True else "false" if value is False else str(value)
+    kind = definition.get("type", "string")
+    if kind == "number":
+        return "1"
+    if kind == "bool":
+        return "false"
+    if definition.get("enum"):
+        return str(definition["enum"][0])
+    return "example"
+
+
+def build_values(manifest):
+    values = dict(CONTEXT)
+    for definition in manifest.get("inputs", []) or []:
+        values[".Inputs." + definition["name"]] = placeholder(definition)
+    return values
+
+
 EXPRESSION = re.compile(r"\$\{\{-?\s*(\.[A-Za-z0-9_.]+)\s*-?\}\}")
 
-# Files copied verbatim by the real engine. Substituting in them here would be
-# wrong, and in the workflows it would eat GitHub Actions' own expressions.
-def is_raw(rel):
-    return (
-        rel.startswith(".github/workflows/")
-        or rel.startswith("charts/")
-        or rel.startswith("plans/")
-        or rel.endswith(".sh")
-    )
+# Which files the real engine copies verbatim, read from the template's own
+# skeleton.raw globs rather than assumed. The two conventions in this repository
+# disagree about charts and workflows on purpose — one exempts them with a glob,
+# the other escapes each expression and lets them render — so guessing here
+# renders files that should not be, and skips files that should.
+#
+# Matched the way Wayfinder matches them: Go's path.Match, where `*` never
+# crosses a `/` and there is no `**`. fnmatch's `*` DOES cross `/`, hence the
+# segment-count guard.
+def raw_matcher(globs):
+    def is_raw(rel):
+        for pattern in globs:
+            if pattern.count("/") != rel.count("/"):
+                continue
+            if fnmatch.fnmatchcase(rel, pattern):
+                return True
+        return False
+
+    return is_raw
+
+
+with open(MANIFEST, encoding="utf-8") as handle:
+    manifest = yaml.safe_load(handle)
+is_raw = raw_matcher((manifest.get("skeleton", {}) or {}).get("raw", []) or [])
+VALUES = build_values(manifest)
 
 
 def substitute(text):
     def replace(match):
         key = match.group(1)
         if key not in VALUES:
-            raise SystemExit(f"render-for-build.sh does not know {key}; add it to VALUES")
+            raise SystemExit(
+                f"render-for-build.sh cannot resolve the expression for {key}: it is not a declared "
+                "input of this template, and not part of the render context"
+            )
         return VALUES[key]
 
     return EXPRESSION.sub(replace, text)

--- a/repo-templates/java-app/README.md
+++ b/repo-templates/java-app/README.md
@@ -1,0 +1,79 @@
+# Java Spring Boot service template
+
+A Java service on Spring Boot, built with Maven on Java 21, with a Wayfinder
+stack that runs it on Kubernetes alongside an S3 bucket it reaches through
+workload identity.
+
+This directory is the template definition. It is not itself a Java project — the
+project lives under `skeleton/`, and only that is written into a new repository.
+
+The package is a fixed `com.example.app` rather than one derived from the service
+name. Renaming a package is a single IDE refactor; templating one means threading
+it through every file, the build and the container image for no real gain.
+
+There is no Maven wrapper: GitHub runners ship Maven and a JDK, and the container
+build uses a Maven base image. Add one with `mvn wrapper:wrapper` if you want it.
+
+| File | What it is |
+| --- | --- |
+| `wayfinder-template.yaml` | The template: its inputs, and which files are copied raw. |
+| `RepoTemplate-java-app.yaml` | Registers the template with Wayfinder. |
+| `skeleton/` | Everything written into the generated repository. |
+
+## Using it
+
+```bash
+wf apply -f RepoTemplate-java-app.yaml
+wf create stack payments --from-template java-app --input serviceName=payments --dry-run
+```
+
+Drop `--dry-run` and add `--github-org` and `--workspace` to create the
+repository for real. See [../DELIVERY-PIPELINE.md](../DELIVERY-PIPELINE.md) for what CI does and what it needs first.
+
+## What the generated repository contains
+
+```
+payments/
+├── README.md
+├── Wayfinder.yaml              app + S3 bucket, wired by workload identity
+├── Makefile                    ci-setup / test / lint / build — what CI calls
+├── Dockerfile                  layered build, eclipse-temurin:21-jre, non-root
+├── pom.xml
+├── src/main/java/com/example/app/
+├── src/main/resources/application.yaml
+├── src/test/java/com/example/app/
+├── charts/app/                 the workload chart
+├── plans/                      the CloudResourcePlan for the bucket
+├── .wayfinder/                 ci.env (this repo's identity) + ci-env.sh
+└── .github/workflows/          ci · preview teardown · deploy develop · deploy prod
+```
+
+## Inputs
+
+`serviceName` is the only required one. It is used for the package name,
+the image name, the Helm release and the stack instance names.
+
+Everything else is optional and defaulted, so `--input serviceName=payments
+--no-input` is enough to scaffold from CI. The two worth setting deliberately:
+
+- `gatewayName` — name an existing Gateway API Gateway to publish the service.
+  Left blank, the service deploys but is reachable in-cluster only.
+- `workspace` — leave blank to take the workspace from the `WF_WORKSPACE`
+  GitHub variable instead, which is better when one workspace serves many
+  repositories.
+
+Run `wf get repotemplate java-app -o yaml` to see the full list with defaults.
+
+## Editing this template
+
+- **`skeleton/.github/workflows/*` and `skeleton/charts/**` are raw.** They are
+  copied byte for byte and never rendered, so they must not contain `${{ }}` or
+  `$${{ }}` meant for the scaffolder. Per-repository values belong in
+  `skeleton/.wayfinder/ci.env`, which is rendered.
+- **`skeleton/Wayfinder.yaml` is rendered and mixes two engines.** Every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` so it
+  survives scaffolding as a literal `${{ ... }}`. Getting this wrong fails at
+  the moment someone creates a repository, so check it with `--dry-run`.
+- The workflows are shared across all four templates in this repository. Edit
+  `../_shared/workflows/`, copy the result into every template, and CI will
+  check they match.

--- a/repo-templates/java-app/README.md
+++ b/repo-templates/java-app/README.md
@@ -4,6 +4,10 @@ A Java service on Spring Boot, built with Maven on Java 21, with a Wayfinder
 stack that runs it on Kubernetes alongside an S3 bucket it reaches through
 workload identity.
 
+`RepoTemplate-java-app.yaml` is the object you give Wayfinder — a pointer at this
+directory. `wayfinder-template.yaml` is the template itself, which Wayfinder
+reads once it has followed that pointer. See [../ANATOMY.md](../ANATOMY.md).
+
 This directory is the template definition. It is not itself a Java project — the
 project lives under `skeleton/`, and only that is written into a new repository.
 

--- a/repo-templates/java-app/RepoTemplate-java-app.yaml
+++ b/repo-templates/java-app/RepoTemplate-java-app.yaml
@@ -1,0 +1,30 @@
+# Registers the Java Spring Boot service template with Wayfinder.
+#
+# This repository is public, so Wayfinder reads the template anonymously — no
+# GitHub connection is needed to register it or to preview what it renders.
+# Creating a repository from it does need a connected GitHub organisation.
+#
+#   wf apply -f RepoTemplate-java-app.yaml
+#   wf get repotemplate java-app -o yaml     # check status.manifest synced
+#   wf create stack payments --from-template java-app --input serviceName=payments --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: java-app
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: java
+    framework: spring-boot
+    family: wayfinder-golden-path
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/java-app
+  # Branch or tag to read. Pin this to a tag to hold the template steady —
+  # tracking a branch means every merge changes the template for everyone on the
+  # next resync. Point it at a branch to try a change before merging it.
+  ref: main
+  displayName: Java Spring Boot service
+  category: service

--- a/repo-templates/java-app/skeleton/.dockerignore
+++ b/repo-templates/java-app/skeleton/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.wayfinder
+target
+charts
+plans
+Wayfinder.yaml
+wayfinder-stack.yaml
+README.md

--- a/repo-templates/java-app/skeleton/.github/dependabot.yml
+++ b/repo-templates/java-app/skeleton/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps this repository current on its own, rather than relying on the template
+# it was scaffolded from being re-run.
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      maven-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/repo-templates/java-app/skeleton/.github/workflows/ci.yaml
+++ b/repo-templates/java-app/skeleton/.github/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/java-app/skeleton/.github/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/java-app/skeleton/.github/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/java-app/skeleton/.github/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/java-app/skeleton/.github/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/java-app/skeleton/.github/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/java-app/skeleton/.github/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/java-app/skeleton/.gitignore
+++ b/repo-templates/java-app/skeleton/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.class
+
+# Written by `wf up` to remember the stack instance you last deployed to.
+.wfup

--- a/repo-templates/java-app/skeleton/.wayfinder/ci-env.sh
+++ b/repo-templates/java-app/skeleton/.wayfinder/ci-env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Resolves the Wayfinder context for one CI stage and exports it to the job.
+#
+#   usage: .wayfinder/ci-env.sh <preview|develop|prod>
+#
+# Reads .wayfinder/ci.env, which Wayfinder wrote when this repository was
+# scaffolded, combines it with the WF_* GitHub variables set on the repository
+# or organisation, and writes the result to $GITHUB_ENV so later steps can use
+# it directly. Deployment target flags are written one per line to a file whose
+# path lands in WF_DEPLOY_ARGS_FILE; read them with `mapfile -t args < "$FILE"`.
+#
+# Exports:
+#   WAYFINDER_TENANT, WAYFINDER_WORKSPACE, WAYFINDER_ENVIRONMENT
+#   WAYFINDER_SERVICE_ACCOUNT  the CLI authenticates with this implicitly
+#   WF_INSTANCE                the stack instance for this stage
+#   WF_DEPLOY_ARGS_FILE        --target/--identity/--region/--dns-zone flags
+#   plus everything in .wayfinder/ci.env
+set -euo pipefail
+
+stage="${1:-}"
+if [[ -z "${stage}" ]]; then
+  echo "::error::usage: .wayfinder/ci-env.sh <preview|develop|prod>"
+  exit 1
+fi
+
+# shellcheck source=ci.env disable=SC1091
+source .wayfinder/ci.env
+
+case "${stage}" in
+  preview)
+    if [[ -z "${PR_NUMBER:-}" ]]; then
+      echo "::error::PR_NUMBER must be set for the preview stage."
+      exit 1
+    fi
+    environment="${WF_ENV_PREVIEW}"
+    account="${WF_SA_PREVIEW}"
+    instance="${WF_SERVICE_NAME}-pr${PR_NUMBER}"
+    ;;
+  develop)
+    environment="${WF_ENV_DEVELOP}"
+    account="${WF_SA_DEVELOP}"
+    instance="${WF_INSTANCE_DEVELOP}"
+    ;;
+  prod)
+    environment="${WF_ENV_PROD}"
+    account="${WF_SA_PROD}"
+    instance="${WF_INSTANCE_PROD}"
+    ;;
+  *)
+    echo "::error::Unknown stage '${stage}'. Expected preview, develop or prod."
+    exit 1
+    ;;
+esac
+
+# The workspace is a scaffold-time input. Where it was left blank, fall back to
+# the WF_WORKSPACE repository or organisation variable, which is the better
+# place for it when one workspace serves many repositories.
+workspace="${WF_WORKSPACE:-${WF_WORKSPACE_VAR:-}}"
+if [[ -z "${workspace}" ]]; then
+  echo "::error::No Wayfinder workspace. Set the WF_WORKSPACE repository or organisation variable."
+  exit 1
+fi
+
+args_file="${RUNNER_TEMP:-/tmp}/wf-deploy-args"
+: >"${args_file}"
+
+# A cluster in the workspace and environment already selected above, narrowed to
+# a namespace named after the instance so each deployment is isolated.
+if [[ -n "${WF_HOST_CLUSTER:-}" ]]; then
+  printf '%s\n' "--target" "k8s:${WF_HOST_CLUSTER}:${instance}" >>"${args_file}"
+fi
+# The cloud identity Wayfinder provisions cloud resources through. Wayfinder
+# reads the account it reaches, so no separate --target is needed for the cloud.
+if [[ -n "${WF_IDENTITY:-}" ]]; then
+  printf '%s\n' "--identity" "${WF_IDENTITY}" >>"${args_file}"
+fi
+if [[ -n "${WF_REGION:-}" ]]; then
+  printf '%s\n' "--region" "${WF_REGION}" >>"${args_file}"
+fi
+if [[ -n "${WF_DNS_ZONE:-}" ]]; then
+  printf '%s\n' "--dns-zone" "${WF_DNS_ZONE}" >>"${args_file}"
+fi
+
+{
+  # $GITHUB_ENV accepts KEY=value lines only, so the comments in ci.env are
+  # filtered out rather than passed through.
+  grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env
+  echo "WF_INSTANCE=${instance}"
+  echo "WF_DEPLOY_ARGS_FILE=${args_file}"
+  echo "WAYFINDER_TENANT=${WF_TENANT}"
+  echo "WAYFINDER_WORKSPACE=${workspace}"
+  echo "WAYFINDER_ENVIRONMENT=${environment}"
+  echo "WAYFINDER_SERVICE_ACCOUNT=${WF_TENANT}:${workspace}:${account}"
+} >>"${GITHUB_ENV:?GITHUB_ENV is not set; this script is meant to run in GitHub Actions}"
+
+echo "Stage ${stage}: instance ${instance} in ${WF_TENANT}:${workspace}:${environment}"
+echo "Deploying as service account ${WF_TENANT}:${workspace}:${account}"

--- a/repo-templates/java-app/skeleton/.wayfinder/ci.env
+++ b/repo-templates/java-app/skeleton/.wayfinder/ci.env
@@ -1,0 +1,36 @@
+# Wayfinder wrote this file when it created this repository.
+#
+# It holds the values that identify THIS repository to Wayfinder. Every CI job
+# loads it, so this is where to add a new per-repository value — the workflows
+# themselves are copied verbatim from the template and carry no repository
+# specifics.
+#
+# Values that differ per Wayfinder installation rather than per repository
+# (server URL, host cluster, cloud identity, DNS zone) are GitHub repository or
+# organisation variables instead. See .github/workflows/ and the template README.
+
+# Identity
+WF_SERVICE_NAME=${{ .Inputs.serviceName }}
+WF_TENANT=${{ .Tenant }}
+# Blank means "use the WF_WORKSPACE GitHub variable".
+WF_WORKSPACE=${{ .Inputs.workspace }}
+WF_APP_PORT=${{ .Inputs.port }}
+
+# Environments
+WF_ENV_PREVIEW=${{ .Inputs.previewEnvironment }}
+WF_ENV_DEVELOP=${{ .Inputs.developEnvironment }}
+WF_ENV_PROD=${{ .Inputs.prodEnvironment }}
+
+# Stack instances. Preview instances are named <service>-pr<number> at run time.
+WF_INSTANCE_DEVELOP=${{ .Inputs.serviceName }}-develop
+WF_INSTANCE_PROD=${{ .Inputs.serviceName }}-prod
+
+# Service accounts, one per environment, so a leaked preview credential cannot
+# deploy to production. Each is <tenant>:<workspace>:<name> at run time.
+WF_SA_PREVIEW=${{ .Inputs.serviceName }}-ci-preview
+WF_SA_DEVELOP=${{ .Inputs.serviceName }}-ci-develop
+WF_SA_PROD=${{ .Inputs.serviceName }}-ci-prod
+
+# Container image
+WF_IMAGE_REGISTRY=${{ .Inputs.registry }}
+WF_IMAGE_REPO=${{ .Inputs.registry }}/${{ .Repo.Organization }}/${{ .Repo.Name }}

--- a/repo-templates/java-app/skeleton/Dockerfile
+++ b/repo-templates/java-app/skeleton/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build -----------------------------------------------------------------
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /src
+
+# Dependencies first, so a source-only change reuses the cached layer.
+COPY pom.xml ./
+RUN mvn --batch-mode --no-transfer-progress dependency:go-offline
+
+COPY src ./src
+
+# VERSION is passed by CI: the git tag for a release, the short SHA otherwise.
+ARG VERSION=dev
+RUN mvn --batch-mode --no-transfer-progress package -DskipTests \
+    && mv target/*.jar /app.jar
+
+# ---- Run -------------------------------------------------------------------
+# JRE rather than JDK: nothing here compiles, and the toolchain is a large
+# attack surface to carry into production for no benefit.
+FROM eclipse-temurin:21-jre
+
+ARG VERSION=dev
+ENV RELEASE=${VERSION}
+
+RUN useradd --create-home --uid 10001 app
+WORKDIR /app
+
+COPY --from=build --chown=app:app /app.jar ./app.jar
+
+USER app
+EXPOSE ${{ .Inputs.port }}
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75", "-jar", "/app/app.jar"]

--- a/repo-templates/java-app/skeleton/Makefile
+++ b/repo-templates/java-app/skeleton/Makefile
@@ -1,0 +1,48 @@
+# The CI workflows call `make ci-setup`, `make test`, `make lint` and
+# `make build` and nothing else. That is deliberate: it keeps the workflows
+# identical across every Wayfinder service template, whatever the language.
+# Change how this service is built here, not in .github/workflows/.
+RELEASE ?= dev
+
+# GitHub runners ship several JDKs and default to an older one. JAVA_HOME_21_X64
+# is set by the runner image; falling back to JAVA_HOME keeps this working on a
+# laptop that has just the one.
+export JAVA_HOME := $(if $(JAVA_HOME_21_X64),$(JAVA_HOME_21_X64),$(JAVA_HOME))
+
+# No Maven wrapper: GitHub runners ship Maven and the container build uses a
+# Maven base image, so a wrapper would only be one more thing to keep current.
+# Add one with `mvn wrapper:wrapper` if your team prefers it.
+MVN := mvn --batch-mode --no-transfer-progress
+
+.PHONY: all
+all: lint test
+
+# Maven and a JDK are already on GitHub runners, so there is nothing to install.
+.PHONY: ci-setup
+ci-setup:
+	$(MVN) --version
+
+.PHONY: test
+test:
+	$(MVN) test
+
+# Compiles with -Xlint:all -Werror (see pom.xml), so a warning fails the build.
+.PHONY: lint
+lint:
+	$(MVN) --quiet compile
+
+.PHONY: build
+build:
+	$(MVN) package -DskipTests
+
+.PHONY: run
+run:
+	$(MVN) spring-boot:run
+
+.PHONY: image
+image:
+	docker build --build-arg VERSION=$(RELEASE) -t ${{ .Inputs.serviceName }}:$(RELEASE) .
+
+.PHONY: clean
+clean:
+	$(MVN) clean

--- a/repo-templates/java-app/skeleton/README.md
+++ b/repo-templates/java-app/skeleton/README.md
@@ -1,0 +1,130 @@
+# ${{ .Inputs.serviceName }}
+
+${{ .Inputs.description }}
+
+Scaffolded by Wayfinder from the `java-app` template.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `src/main/java/com/example/app/` | The service. Spring Boot with `/`, `/healthz` and `/readyz`. |
+| `src/test/java/` | The JUnit suite. |
+| `pom.xml` | Dependencies and build, versions pinned. |
+| `Wayfinder.yaml` | The stack: what gets deployed and what it needs. |
+| `charts/app/` | The Helm chart for the workload. |
+| `plans/` | The CloudResourcePlan backing the storage component. |
+| `.wayfinder/ci.env` | This repository's Wayfinder identity, read by every CI job. |
+| `.github/workflows/` | Pull request previews, deploy to develop, deploy to production. |
+
+## Running it locally
+
+```bash
+make test     # mvn test
+make lint     # compiles with -Xlint:all -Werror
+make run      # mvn spring-boot:run on port ${{ .Inputs.port }}
+```
+
+```bash
+curl localhost:${{ .Inputs.port }}/healthz
+curl localhost:${{ .Inputs.port }}/
+```
+
+## Deploying it
+
+CI deploys this service for you. If you want to deploy a copy of your own from
+your laptop, into your own instance:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+wf down -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+```
+
+`wf up` needs an image to run, so pass one that already exists:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER --env-var IMAGE=<registry>/<org>/<repo>:<tag> --env-var RELEASE=local
+```
+
+## How CI works
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `${{ .Inputs.serviceName }}-pr<number>` is deployed in `${{ .Inputs.previewEnvironment }}` and its URL is commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | Tests run, an image tagged `sha-<short sha>` is built, and `${{ .Inputs.serviceName }}-develop` is deployed in `${{ .Inputs.developEnvironment }}`. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `${{ .Inputs.serviceName }}-prod` in `${{ .Inputs.prodEnvironment }}`. |
+
+Cutting a release is therefore:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Where CI configuration lives
+
+Nothing repository-specific is written into the workflow files — they are
+copied verbatim from the template so they stay upgradeable. Configuration
+splits in two:
+
+- **`.wayfinder/ci.env`** — values specific to this repository: the service
+  name, tenant, environments, service accounts and image repository. Add new
+  per-repository values here.
+- **GitHub repository or organisation variables** — values specific to your
+  Wayfinder installation, shared by every repository:
+
+  | Variable | What it is |
+  | --- | --- |
+  | `WF_SERVER` | Wayfinder API URL. |
+  | `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+  | `WF_WORKSPACE` | Workspace to deploy into, when `.wayfinder/ci.env` leaves it blank. |
+  | `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+  | `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+  | `WF_REGION` | Cloud region. |
+  | `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+  | `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides. Each falls back to the value above. |
+  | `WF_PROD_REQUIRE_APPROVAL` | Set to `true` to make production deploys pause for plan approval. |
+  | `WF_EXPECT_INSTANCE_ID` | Guards production against a misconfigured `WF_SERVER`. |
+
+### What CI needs before it can run
+
+Three Wayfinder service accounts, one per environment, each trusting a
+different GitHub OIDC subject so a preview credential cannot reach production:
+
+```bash
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-preview -w <workspace>
+wf create serviceaccountcredential github-preview \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-preview \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-pull-request
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-develop -w <workspace>
+wf create serviceaccountcredential github-develop \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-develop \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment develop
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-prod -w <workspace>
+wf create serviceaccountcredential github-prod \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-prod \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment production
+```
+
+Each needs the `deployer` role in its environment. The preview account also
+needs catalogue write, because `Wayfinder.yaml` refers to its plan as
+`file:plans/...`, which publishes that plan to the workspace catalogue — and
+that happens on a dry run too.
+
+You also need GitHub environments named `develop` and `production` (put your
+reviewers on `production`), and the cluster must be able to pull your image.
+Packages published to GHCR are private by default, so either make the package
+public or give the cluster an image pull secret.
+
+## Storage
+
+`Wayfinder.yaml` provisions an S3 bucket per stack instance and grants this
+service read-write access to it. The bucket name arrives as `BUCKET_NAME`.
+There are no credentials anywhere in this repository: the pod authenticates
+with its own cloud identity, which Wayfinder attaches to its Kubernetes service
+account.
+
+To drop the bucket, remove the `storage` component from `Wayfinder.yaml` along
+with the `workloadIdentity` block and the `env` entries that reference it.

--- a/repo-templates/java-app/skeleton/Wayfinder.yaml
+++ b/repo-templates/java-app/skeleton/Wayfinder.yaml
@@ -1,0 +1,87 @@
+# The Wayfinder stack for this service: what gets deployed, and what it needs.
+#
+# Two things here are filled in when you deploy, not when you edit:
+#
+#   $${{ ... }}  A Wayfinder stack expression. Component outputs, workload
+#               identity annotations and variables are resolved at deploy time.
+#   ${NAME}     Supplied by CI with `wf deploy --env-var NAME=value`. Every one
+#               must resolve, and an --env-var nothing references is rejected.
+#
+# Deploy it yourself with `wf up -i <instance>`; see `wf deploy --help`.
+apiVersion: v1
+name: ${{ .Stack.Name }}
+description: "${{ .Inputs.description }}"
+
+# Deploy-time settings you can vary per environment without editing this file:
+#   wf set var replicas --value 3 -w <workspace> -e prod
+# Values resolve down the tenant > workspace > environment > instance hierarchy.
+vars:
+  - name: replicas
+    description: Number of pods to run.
+    type: number
+    optional: true
+    defaultValue: 1
+
+components:
+${{- if .Inputs.includeStorage }}
+  # An S3 bucket for this service's data, created per stack instance — every
+  # preview, develop and production deployment gets its own.
+  #
+  # This is a provider component: it publishes consumption policies rather than
+  # credentials. The `app` component below is granted one of them, and Wayfinder
+  # turns that grant into the IAM policy on the workload's own identity. No
+  # access keys exist anywhere in this repository.
+  storage:
+    type: CloudResource
+    plan: ${{ .Inputs.storagePlan }}
+    inputs:
+      - name: suffix
+        value: data
+${{ end }}
+  app:
+    type: KubeResource
+${{- if .Inputs.gatewayName }}
+    outputs:
+      - name: url
+        description: Public URL of the service.
+        valueTemplate: "https://$${{ getDNSEntry }}"
+${{- end }}
+${{- if .Inputs.includeStorage }}
+    workloadIdentity:
+      serviceAccountName: ${{ .Inputs.serviceName }}
+      access:
+        - to: storage
+          consumptionPolicy: read-write
+${{- end }}
+    helm:
+      chartPath: charts/app
+      chartName: app
+      valuesTemplate: |
+        image: "${IMAGE}"
+        release: "${RELEASE}"
+        port: ${{ .Inputs.port }}
+        replicas: $${{ .Vars.replicas }}
+        serviceAccount:
+          name: ${{ .Inputs.serviceName }}
+${{- if .Inputs.includeStorage }}
+          annotations:
+        $${{ .WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+        env:
+          BUCKET_NAME: "$${{ .Components.storage.s3_bucket_id }}"
+          BUCKET_ARN: "$${{ .Components.storage.s3_bucket_arn }}"
+${{- end }}
+        httpRoute:
+${{- if .Inputs.gatewayName }}
+          enabled: true
+          hostname: "$${{ getDNSEntry }}"
+          parentGateway:
+            name: ${{ .Inputs.gatewayName }}
+${{- if .Inputs.gatewayNamespace }}
+            namespace: ${{ .Inputs.gatewayNamespace }}
+${{- end }}
+${{- else }}
+          # No Gateway was named when this repository was scaffolded, so the
+          # service is reachable inside the cluster only. To publish it, set
+          # httpRoute.enabled and name a Gateway that exists in this environment.
+          enabled: false
+${{- end }}

--- a/repo-templates/java-app/skeleton/charts/app/Chart.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: The workload for this service, deployed by the Wayfinder stack in Wayfinder.yaml.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/repo-templates/java-app/skeleton/charts/app/templates/_helpers.tpl
+++ b/repo-templates/java-app/skeleton/charts/app/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.serviceAccountName" -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.release | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/repo-templates/java-app/skeleton/charts/app/templates/deployment.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Rolls the pods when the release changes even if the image tag does not.
+        wayfinder.appvia.io/release: {{ .Values.release | quote }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ include "app.name" . }}
+          image: {{ required "image is required; it is supplied by CI as ${IMAGE}" .Values.image | quote }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: RELEASE
+              value: {{ .Values.release | quote }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/repo-templates/java-app/skeleton/charts/app/templates/httproute.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ required "httpRoute.parentGateway.name is required when httpRoute.enabled is true" .Values.httpRoute.parentGateway.name }}
+      {{- with .Values.httpRoute.parentGateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled is true" .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "app.fullname" . }}
+          port: {{ .Values.port }}
+{{- end }}

--- a/repo-templates/java-app/skeleton/charts/app/templates/service.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/repo-templates/java-app/skeleton/charts/app/templates/serviceaccount.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  # Wayfinder puts the cloud workload identity annotations here, which is how
+  # the pod authenticates to its cloud resources without any stored credentials.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/repo-templates/java-app/skeleton/charts/app/values.yaml
+++ b/repo-templates/java-app/skeleton/charts/app/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for a standalone `helm template`. In a real deployment every value
+# here is overwritten by the valuesTemplate in Wayfinder.yaml, which is where
+# the image tag, the workload identity annotations and the storage outputs come
+# from. Edit Wayfinder.yaml, not this file, unless you are adding a new value.
+
+# Container image reference. CI supplies this as ${IMAGE} at deploy time.
+image: ""
+
+# The release this is: a git tag, or sha-<short sha>.
+release: dev
+
+port: 8080
+replicas: 1
+
+serviceAccount:
+  name: app
+  # Wayfinder writes the cloud workload identity annotations here. That is what
+  # lets the pod reach its cloud resources with no credentials in the cluster.
+  annotations: {}
+
+# Environment variables for the container, as a plain name/value map.
+env: {}
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentGateway:
+    name: ""
+    # Leave blank when the Gateway is in this service's own namespace.
+    namespace: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/repo-templates/java-app/skeleton/plans/aws-s3-data-bucket.yaml
+++ b/repo-templates/java-app/skeleton/plans/aws-s3-data-bucket.yaml
@@ -1,0 +1,144 @@
+apiVersion: cloudresources/v3
+kind: CloudResourcePlan
+metadata:
+  name: aws-s3-data-bucket
+  version: "1.0.0"
+spec:
+  cloud: aws
+  description: "S3 bucket for application data, with read-only / read-write / write-only consumption policies that other components can be granted."
+  inputs:
+    - name: versioning
+      description: "Enable object versioning. Use with caution — makes deletion harder."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: disable_force_destroy
+      description: "Disable force destroy. Use with caution — teardown will fail while objects remain."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: suffix
+      description: "Differentiates buckets within a stack instance. Combined with stack+instance to form the bucket prefix."
+      type: string
+      optional: true
+      defaultValue: "data"
+
+  # This is a PROVIDER plan: it has no workload identity of its own. Instead it
+  # publishes consumption policies that other components can be granted from the
+  # manifest. Wayfinder turns a grant into the IAM policy below and attaches it to
+  # the consumer's role — no IAM written by hand.
+  consumptionPolicies:
+    - name: read-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: read-write
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadWrite",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: write-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppWriteOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+
+  terraform:
+    modules:
+      - name: s3_bucket
+        source: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+        version: "v4.1.2"
+    files:
+      - name: main.tf
+        template: |
+          module "s3_bucket" {
+            source = ${{ .Modules.s3_bucket.Source | quote }}
+
+            bucket_prefix = "${{ .Stack.Name }}-${{ .Stack.Instance.Name }}-${{ .Inputs.suffix }}-"
+
+            ${{- if .Inputs.versioning }}
+            versioning = {
+              enabled = true
+            }
+            ${{- end }}
+
+            server_side_encryption_configuration = {
+              rule = {
+                apply_server_side_encryption_by_default = {
+                  sse_algorithm = "AES256"
+                }
+              }
+            }
+
+            # AWS blocks public access on new buckets by default; don't attach a
+            # public policy (and avoid s3:PutBucketPublicAccessBlock, which some
+            # account guardrails deny).
+            attach_public_policy = false
+
+            ${{- if not .Inputs.disable_force_destroy }}
+            force_destroy = true
+            ${{- end }}
+
+            tags = {
+              Application = "${{ .Stack.Name }}"
+              Environment = "${{ .Stack.Instance.Name }}"
+              ManagedBy   = "Wayfinder"
+            }
+          }
+      - name: outputs.tf
+        template: |
+          output "s3_bucket_arn" {
+            value = module.s3_bucket.s3_bucket_arn
+          }
+          output "s3_bucket_id" {
+            value = module.s3_bucket.s3_bucket_id
+          }

--- a/repo-templates/java-app/skeleton/pom.xml
+++ b/repo-templates/java-app/skeleton/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.4.2</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>${{ .Inputs.serviceName }}</artifactId>
+  <version>0.1.0</version>
+  <name>${{ .Inputs.serviceName }}</name>
+  <description>${{ .Inputs.description }}</description>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- Actuator gives the richer /actuator/health for operators. The plain
+         /healthz and /readyz the chart probes are served by HealthController,
+         so the probes do not depend on actuator staying enabled. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <!-- `make lint` runs this. Failing the build on a warning keeps the
+           generated repository honest from its first commit rather than
+           accumulating them. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/repo-templates/java-app/skeleton/src/main/java/com/example/app/Application.java
+++ b/repo-templates/java-app/skeleton/src/main/java/com/example/app/Application.java
@@ -1,0 +1,20 @@
+package com.example.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * ${{ .Inputs.description }}
+ *
+ * <p>The package is {@code com.example.app} rather than something derived from the
+ * service name: a package rename is a single IDE refactor, whereas a templated
+ * package name has to be threaded through every file and the build. Rename it
+ * once, here and in {@code pom.xml}, if you want your own.
+ */
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/repo-templates/java-app/skeleton/src/main/java/com/example/app/HealthController.java
+++ b/repo-templates/java-app/skeleton/src/main/java/com/example/app/HealthController.java
@@ -1,0 +1,33 @@
+package com.example.app;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Liveness and readiness for the Helm chart's probes.
+ *
+ * <p>Spring Actuator already serves {@code /actuator/health/liveness} and
+ * {@code /actuator/health/readiness}, and those stay available for operators.
+ * These two exist because every Wayfinder service template answers on
+ * {@code /healthz} and {@code /readyz}, so one chart probes them all — and
+ * because a probe that depends on actuator staying enabled is a probe that
+ * breaks the day someone trims dependencies.
+ *
+ * <p>Keep both cheap and dependency-free. A readiness check that talks to a
+ * database will take the pod out of service the moment the database hiccups,
+ * which is rarely what you want.
+ */
+@RestController
+public class HealthController {
+
+  @GetMapping("/healthz")
+  public Map<String, String> healthz() {
+    return Map.of("status", "ok");
+  }
+
+  @GetMapping("/readyz")
+  public Map<String, String> readyz() {
+    return Map.of("status", "ok");
+  }
+}

--- a/repo-templates/java-app/skeleton/src/main/java/com/example/app/ServiceController.java
+++ b/repo-templates/java-app/skeleton/src/main/java/com/example/app/ServiceController.java
@@ -1,0 +1,33 @@
+package com.example.app;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Reports what this service is and which release is running. */
+@RestController
+public class ServiceController {
+
+  /**
+   * Set at build time by CI: the git tag for a release, the short SHA otherwise, so a running pod
+   * can always be traced back to a commit.
+   */
+  @Value("${RELEASE:dev}")
+  private String release;
+
+  /**
+   * Set by the Helm chart from the storage component's output. The workload reaches the bucket
+   * through its own cloud identity, so there are no credentials to read here.
+   */
+  @Value("${BUCKET_NAME:}")
+  private String bucketName;
+
+  @GetMapping("/")
+  public Map<String, String> root() {
+    return Map.of(
+        "service", "${{ .Inputs.serviceName }}",
+        "release", release,
+        "bucket", bucketName);
+  }
+}

--- a/repo-templates/java-app/skeleton/src/main/resources/application.yaml
+++ b/repo-templates/java-app/skeleton/src/main/resources/application.yaml
@@ -1,0 +1,27 @@
+server:
+  port: ${PORT:${{ .Inputs.port }}}
+  shutdown: graceful
+
+spring:
+  application:
+    name: ${{ .Inputs.serviceName }}
+  lifecycle:
+    # Give in-flight requests a chance to finish when Kubernetes sends SIGTERM,
+    # rather than severing them mid-roll.
+    timeout-per-shutdown-phase: 20s
+
+management:
+  endpoints:
+    web:
+      exposure:
+        # Health and info only. Exposing everything puts env, mappings and
+        # thread dumps on the network, which is rarely what you want in a
+        # cluster.
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      # Per-dependency detail is useful to an operator reading the endpoint
+      # directly; the chart's probes use /healthz and /readyz and do not need it.
+      show-details: when-authorized

--- a/repo-templates/java-app/skeleton/src/test/java/com/example/app/ApplicationTests.java
+++ b/repo-templates/java-app/skeleton/src/test/java/com/example/app/ApplicationTests.java
@@ -1,0 +1,44 @@
+package com.example.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ApplicationTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void livenessReportsOk() throws Exception {
+    mockMvc.perform(get("/healthz")).andExpect(status().isOk()).andExpect(jsonPath("$.status").value("ok"));
+  }
+
+  @Test
+  void readinessReportsOk() throws Exception {
+    mockMvc.perform(get("/readyz")).andExpect(status().isOk()).andExpect(jsonPath("$.status").value("ok"));
+  }
+
+  @Test
+  void rootReportsTheServiceIdentity() throws Exception {
+    mockMvc
+        .perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.service").value("${{ .Inputs.serviceName }}"))
+        // Always reports something, even 'dev'.
+        .andExpect(jsonPath("$.release").isNotEmpty());
+  }
+
+  @Test
+  void contextLoads() {
+    assertThat(mockMvc).isNotNull();
+  }
+}

--- a/repo-templates/java-app/wayfinder-template.yaml
+++ b/repo-templates/java-app/wayfinder-template.yaml
@@ -1,0 +1,146 @@
+# Wayfinder repo template definition.
+#
+# Parsed strictly: an unrecognised key here is an error, not a warning.
+# Everything under skeleton/ is what gets written into the new repository.
+name: Java Spring Boot service
+description: >-
+  A Java service on Spring Boot, built with Maven on Java 21, deployed by a
+  Wayfinder stack that runs the app on Kubernetes alongside an S3 bucket it
+  reaches through workload identity. Ships the standard Wayfinder CI set: pull
+  request previews, deploy to develop on merge, and deploy to production on a
+  tag.
+icon: spring
+
+inputs:
+  # The only required input. Everything else has a default so the template can
+  # be scaffolded from the catalogue, or from CI with --no-input, by supplying
+  # nothing but a name.
+  - name: serviceName
+    description: >-
+      Name of the service. Used for the Go command package, the container image,
+      the Helm release and the develop and production stack instance names.
+    type: string
+    minLength: 2
+    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+
+  - name: description
+    description: One line describing what this service does.
+    type: string
+    optional: true
+    defaultValue: "A Java Spring Boot service scaffolded by Wayfinder"
+    maxLength: 200
+
+  - name: owner
+    description: Team that owns this service. Written into the README and CODEOWNERS.
+    type: string
+    optional: true
+    defaultValue: ""
+    maxLength: 60
+
+  # The scaffold context has no workspace, so CI needs to be told which one to
+  # deploy into. Leave blank to fall back to the WF_WORKSPACE GitHub variable,
+  # which is the better choice when one workspace serves many repositories.
+  - name: workspace
+    description: >-
+      Wayfinder workspace CI deploys into. Leave blank to take it from the
+      WF_WORKSPACE GitHub repository or organisation variable instead.
+    type: string
+    optional: true
+    defaultValue: ""
+    pattern: "^([a-z][a-z0-9-]*[a-z0-9])?$"
+
+  - name: developEnvironment
+    description: Environment deployed to on every merge to the default branch.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: prodEnvironment
+    description: Environment deployed to when a release tag is pushed.
+    type: string
+    optional: true
+    defaultValue: "prod"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: previewEnvironment
+    description: Environment pull request preview instances are created in.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: registry
+    description: Container registry the service image is published to.
+    type: string
+    optional: true
+    defaultValue: "ghcr.io"
+    enum: ["ghcr.io", "quay.io", "docker.io"]
+
+  - name: port
+    description: TCP port the service listens on.
+    type: number
+    optional: true
+    defaultValue: 8080
+    minimum: 1
+    maximum: 65535
+
+  - name: includeStorage
+    description: >-
+      Provision an S3 bucket alongside the service and grant the workload
+      read-write access to it through workload identity.
+    type: bool
+    optional: true
+    defaultValue: true
+
+  - name: storagePlan
+    description: >-
+      CloudResourcePlan backing the storage component. Defaults to the plan
+      bundled in the generated repository, so the stack deploys with no
+      catalogue prerequisite. Set it to a catalogue reference such as
+      aws-s3-data-bucket@1.0.0 to use your platform team's plan instead.
+    type: string
+    optional: true
+    defaultValue: "file:plans/aws-s3-data-bucket.yaml"
+
+  # Exposing the service needs a Gateway that already exists in the target
+  # environment, which only the platform team knows. With no gateway named, the
+  # service still deploys but is reachable only inside the cluster.
+  - name: gatewayName
+    description: >-
+      Name of an existing Gateway API Gateway to publish the service through.
+      Leave blank to deploy without an HTTPRoute, reachable in-cluster only.
+    type: string
+    optional: true
+    defaultValue: ""
+
+  - name: gatewayNamespace
+    description: >-
+      Namespace of the Gateway named in gatewayName. Leave blank when the
+      Gateway is in the same namespace as the service.
+    type: string
+    optional: true
+    defaultValue: ""
+
+skeleton:
+  path: skeleton
+
+  # Files listed here are copied byte for byte. Their contents are NOT rendered,
+  # so they must not use the `$${{ }}` escape either — it would land literally.
+  #
+  # Note that these globs are matched with path.Match: `**` is not supported, and
+  # `*.yaml` does not match `*.yml`, which is why both are listed.
+  raw:
+    # GitHub Actions has its own ${{ }} expression syntax. Keeping the workflows
+    # raw means they are valid Actions YAML exactly as written, both here and in
+    # the generated repository. Per-repository values reach them through
+    # .wayfinder/ci.env, which is rendered.
+    - ".github/workflows/*.yaml"
+    - ".github/workflows/*.yml"
+    - ".wayfinder/*.sh"
+    # Helm charts are Helm templating, evaluated at deploy time, not now.
+    - "charts/app/*"
+    - "charts/app/templates/*"
+    # CloudResourcePlans use the Wayfinder stack template engine, not this one.
+    - "plans/*.yaml"

--- a/repo-templates/node-app/README.md
+++ b/repo-templates/node-app/README.md
@@ -1,0 +1,74 @@
+# Node.js Fastify service template
+
+A TypeScript HTTP service on Fastify, with a Wayfinder stack that runs it on
+Kubernetes alongside an S3 bucket it reaches through workload identity.
+
+This directory is the template definition. It is not itself a Node project —
+the project lives under `skeleton/`, and only that is written into a new
+repository.
+
+Fastify rather than Express, deliberately: offering both would mean two
+parallel source trees selected by a conditional for very little difference.
+Swapping in Express is a change to `src/server.ts` and one dependency.
+
+| File | What it is |
+| --- | --- |
+| `wayfinder-template.yaml` | The template: its inputs, and which files are copied raw. |
+| `RepoTemplate-node-app.yaml` | Registers the template with Wayfinder. |
+| `skeleton/` | Everything written into the generated repository. |
+
+## Using it
+
+```bash
+wf apply -f RepoTemplate-node-app.yaml
+wf create stack payments --from-template node-app --input serviceName=payments --dry-run
+```
+
+Drop `--dry-run` and add `--github-org` and `--workspace` to create the
+repository for real. See [../DELIVERY-PIPELINE.md](../DELIVERY-PIPELINE.md) for what CI does and what it needs first.
+
+## What the generated repository contains
+
+```
+payments/
+├── README.md
+├── Wayfinder.yaml              app + S3 bucket, wired by workload identity
+├── Makefile                    test / lint / build — what CI calls
+├── Dockerfile                  node:22-slim, non-root
+├── package.json, package-lock.json, tsconfig.json
+├── src/                        server.ts, server.test.ts
+├── charts/app/                 the workload chart
+├── plans/                      the CloudResourcePlan for the bucket
+├── .wayfinder/                 ci.env (this repo's identity) + ci-env.sh
+└── .github/workflows/          ci · preview teardown · deploy develop · deploy prod
+```
+
+## Inputs
+
+`serviceName` is the only required one. It is used for the package name,
+the image name, the Helm release and the stack instance names.
+
+Everything else is optional and defaulted, so `--input serviceName=payments
+--no-input` is enough to scaffold from CI. The two worth setting deliberately:
+
+- `gatewayName` — name an existing Gateway API Gateway to publish the service.
+  Left blank, the service deploys but is reachable in-cluster only.
+- `workspace` — leave blank to take the workspace from the `WF_WORKSPACE`
+  GitHub variable instead, which is better when one workspace serves many
+  repositories.
+
+Run `wf get repotemplate node-app -o yaml` to see the full list with defaults.
+
+## Editing this template
+
+- **`skeleton/.github/workflows/*` and `skeleton/charts/**` are raw.** They are
+  copied byte for byte and never rendered, so they must not contain `${{ }}` or
+  `$${{ }}` meant for the scaffolder. Per-repository values belong in
+  `skeleton/.wayfinder/ci.env`, which is rendered.
+- **`skeleton/Wayfinder.yaml` is rendered and mixes two engines.** Every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` so it
+  survives scaffolding as a literal `${{ ... }}`. Getting this wrong fails at
+  the moment someone creates a repository, so check it with `--dry-run`.
+- The workflows are shared across all four templates in this repository. Edit
+  `../_shared/workflows/`, copy the result into every template, and CI will
+  check they match.

--- a/repo-templates/node-app/README.md
+++ b/repo-templates/node-app/README.md
@@ -3,6 +3,10 @@
 A TypeScript HTTP service on Fastify, with a Wayfinder stack that runs it on
 Kubernetes alongside an S3 bucket it reaches through workload identity.
 
+`RepoTemplate-node-app.yaml` is the object you give Wayfinder — a pointer at this
+directory. `wayfinder-template.yaml` is the template itself, which Wayfinder
+reads once it has followed that pointer. See [../ANATOMY.md](../ANATOMY.md).
+
 This directory is the template definition. It is not itself a Node project —
 the project lives under `skeleton/`, and only that is written into a new
 repository.

--- a/repo-templates/node-app/RepoTemplate-node-app.yaml
+++ b/repo-templates/node-app/RepoTemplate-node-app.yaml
@@ -1,0 +1,30 @@
+# Registers the Node.js Fastify service template with Wayfinder.
+#
+# This repository is public, so Wayfinder reads the template anonymously — no
+# GitHub connection is needed to register it or to preview what it renders.
+# Creating a repository from it does need a connected GitHub organisation.
+#
+#   wf apply -f RepoTemplate-node-app.yaml
+#   wf get repotemplate node-app -o yaml     # check status.manifest synced
+#   wf create stack payments --from-template node-app --input serviceName=payments --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: node-app
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: typescript
+    framework: fastify
+    family: wayfinder-golden-path
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/node-app
+  # Branch or tag to read. Pin this to a tag to hold the template steady —
+  # tracking a branch means every merge changes the template for everyone on the
+  # next resync. Point it at a branch to try a change before merging it.
+  ref: main
+  displayName: Node.js Fastify service
+  category: service

--- a/repo-templates/node-app/skeleton/.dockerignore
+++ b/repo-templates/node-app/skeleton/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.wayfinder
+node_modules
+charts
+plans
+Wayfinder.yaml
+wayfinder-stack.yaml
+README.md

--- a/repo-templates/node-app/skeleton/.github/dependabot.yml
+++ b/repo-templates/node-app/skeleton/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps this repository current on its own, rather than relying on the template
+# it was scaffolded from being re-run.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/repo-templates/node-app/skeleton/.github/workflows/ci.yaml
+++ b/repo-templates/node-app/skeleton/.github/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/node-app/skeleton/.github/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/node-app/skeleton/.github/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/node-app/skeleton/.github/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/node-app/skeleton/.github/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/node-app/skeleton/.github/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/node-app/skeleton/.github/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/node-app/skeleton/.gitignore
+++ b/repo-templates/node-app/skeleton/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tsbuildinfo
+
+# Written by `wf up` to remember the stack instance you last deployed to.
+.wfup

--- a/repo-templates/node-app/skeleton/.prettierignore
+++ b/repo-templates/node-app/skeleton/.prettierignore
@@ -1,0 +1,17 @@
+# Helm charts and CloudResourcePlans are templates, not YAML documents —
+# formatting them corrupts the Go template syntax inside.
+charts/
+plans/
+Wayfinder.yaml
+
+# Copied verbatim from the Wayfinder repo template; leave them as they came.
+.github/
+.wayfinder/
+
+node_modules/
+package-lock.json
+
+# Markdown came from the repo template with values substituted into it, so
+# table column widths depend on the name you scaffolded with and can never
+# match a fixed alignment. Format prose by hand.
+*.md

--- a/repo-templates/node-app/skeleton/.prettierrc.json
+++ b/repo-templates/node-app/skeleton/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/repo-templates/node-app/skeleton/.wayfinder/ci-env.sh
+++ b/repo-templates/node-app/skeleton/.wayfinder/ci-env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Resolves the Wayfinder context for one CI stage and exports it to the job.
+#
+#   usage: .wayfinder/ci-env.sh <preview|develop|prod>
+#
+# Reads .wayfinder/ci.env, which Wayfinder wrote when this repository was
+# scaffolded, combines it with the WF_* GitHub variables set on the repository
+# or organisation, and writes the result to $GITHUB_ENV so later steps can use
+# it directly. Deployment target flags are written one per line to a file whose
+# path lands in WF_DEPLOY_ARGS_FILE; read them with `mapfile -t args < "$FILE"`.
+#
+# Exports:
+#   WAYFINDER_TENANT, WAYFINDER_WORKSPACE, WAYFINDER_ENVIRONMENT
+#   WAYFINDER_SERVICE_ACCOUNT  the CLI authenticates with this implicitly
+#   WF_INSTANCE                the stack instance for this stage
+#   WF_DEPLOY_ARGS_FILE        --target/--identity/--region/--dns-zone flags
+#   plus everything in .wayfinder/ci.env
+set -euo pipefail
+
+stage="${1:-}"
+if [[ -z "${stage}" ]]; then
+  echo "::error::usage: .wayfinder/ci-env.sh <preview|develop|prod>"
+  exit 1
+fi
+
+# shellcheck source=ci.env disable=SC1091
+source .wayfinder/ci.env
+
+case "${stage}" in
+  preview)
+    if [[ -z "${PR_NUMBER:-}" ]]; then
+      echo "::error::PR_NUMBER must be set for the preview stage."
+      exit 1
+    fi
+    environment="${WF_ENV_PREVIEW}"
+    account="${WF_SA_PREVIEW}"
+    instance="${WF_SERVICE_NAME}-pr${PR_NUMBER}"
+    ;;
+  develop)
+    environment="${WF_ENV_DEVELOP}"
+    account="${WF_SA_DEVELOP}"
+    instance="${WF_INSTANCE_DEVELOP}"
+    ;;
+  prod)
+    environment="${WF_ENV_PROD}"
+    account="${WF_SA_PROD}"
+    instance="${WF_INSTANCE_PROD}"
+    ;;
+  *)
+    echo "::error::Unknown stage '${stage}'. Expected preview, develop or prod."
+    exit 1
+    ;;
+esac
+
+# The workspace is a scaffold-time input. Where it was left blank, fall back to
+# the WF_WORKSPACE repository or organisation variable, which is the better
+# place for it when one workspace serves many repositories.
+workspace="${WF_WORKSPACE:-${WF_WORKSPACE_VAR:-}}"
+if [[ -z "${workspace}" ]]; then
+  echo "::error::No Wayfinder workspace. Set the WF_WORKSPACE repository or organisation variable."
+  exit 1
+fi
+
+args_file="${RUNNER_TEMP:-/tmp}/wf-deploy-args"
+: >"${args_file}"
+
+# A cluster in the workspace and environment already selected above, narrowed to
+# a namespace named after the instance so each deployment is isolated.
+if [[ -n "${WF_HOST_CLUSTER:-}" ]]; then
+  printf '%s\n' "--target" "k8s:${WF_HOST_CLUSTER}:${instance}" >>"${args_file}"
+fi
+# The cloud identity Wayfinder provisions cloud resources through. Wayfinder
+# reads the account it reaches, so no separate --target is needed for the cloud.
+if [[ -n "${WF_IDENTITY:-}" ]]; then
+  printf '%s\n' "--identity" "${WF_IDENTITY}" >>"${args_file}"
+fi
+if [[ -n "${WF_REGION:-}" ]]; then
+  printf '%s\n' "--region" "${WF_REGION}" >>"${args_file}"
+fi
+if [[ -n "${WF_DNS_ZONE:-}" ]]; then
+  printf '%s\n' "--dns-zone" "${WF_DNS_ZONE}" >>"${args_file}"
+fi
+
+{
+  # $GITHUB_ENV accepts KEY=value lines only, so the comments in ci.env are
+  # filtered out rather than passed through.
+  grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env
+  echo "WF_INSTANCE=${instance}"
+  echo "WF_DEPLOY_ARGS_FILE=${args_file}"
+  echo "WAYFINDER_TENANT=${WF_TENANT}"
+  echo "WAYFINDER_WORKSPACE=${workspace}"
+  echo "WAYFINDER_ENVIRONMENT=${environment}"
+  echo "WAYFINDER_SERVICE_ACCOUNT=${WF_TENANT}:${workspace}:${account}"
+} >>"${GITHUB_ENV:?GITHUB_ENV is not set; this script is meant to run in GitHub Actions}"
+
+echo "Stage ${stage}: instance ${instance} in ${WF_TENANT}:${workspace}:${environment}"
+echo "Deploying as service account ${WF_TENANT}:${workspace}:${account}"

--- a/repo-templates/node-app/skeleton/.wayfinder/ci.env
+++ b/repo-templates/node-app/skeleton/.wayfinder/ci.env
@@ -1,0 +1,36 @@
+# Wayfinder wrote this file when it created this repository.
+#
+# It holds the values that identify THIS repository to Wayfinder. Every CI job
+# loads it, so this is where to add a new per-repository value — the workflows
+# themselves are copied verbatim from the template and carry no repository
+# specifics.
+#
+# Values that differ per Wayfinder installation rather than per repository
+# (server URL, host cluster, cloud identity, DNS zone) are GitHub repository or
+# organisation variables instead. See .github/workflows/ and the template README.
+
+# Identity
+WF_SERVICE_NAME=${{ .Inputs.serviceName }}
+WF_TENANT=${{ .Tenant }}
+# Blank means "use the WF_WORKSPACE GitHub variable".
+WF_WORKSPACE=${{ .Inputs.workspace }}
+WF_APP_PORT=${{ .Inputs.port }}
+
+# Environments
+WF_ENV_PREVIEW=${{ .Inputs.previewEnvironment }}
+WF_ENV_DEVELOP=${{ .Inputs.developEnvironment }}
+WF_ENV_PROD=${{ .Inputs.prodEnvironment }}
+
+# Stack instances. Preview instances are named <service>-pr<number> at run time.
+WF_INSTANCE_DEVELOP=${{ .Inputs.serviceName }}-develop
+WF_INSTANCE_PROD=${{ .Inputs.serviceName }}-prod
+
+# Service accounts, one per environment, so a leaked preview credential cannot
+# deploy to production. Each is <tenant>:<workspace>:<name> at run time.
+WF_SA_PREVIEW=${{ .Inputs.serviceName }}-ci-preview
+WF_SA_DEVELOP=${{ .Inputs.serviceName }}-ci-develop
+WF_SA_PROD=${{ .Inputs.serviceName }}-ci-prod
+
+# Container image
+WF_IMAGE_REGISTRY=${{ .Inputs.registry }}
+WF_IMAGE_REPO=${{ .Inputs.registry }}/${{ .Repo.Organization }}/${{ .Repo.Name }}

--- a/repo-templates/node-app/skeleton/Dockerfile
+++ b/repo-templates/node-app/skeleton/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# ---- Dependencies ----------------------------------------------------------
+FROM node:22-slim AS deps
+
+WORKDIR /src
+
+# Lockfile first, so a source-only change reuses the cached install layer.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# ---- Run -------------------------------------------------------------------
+FROM node:22-slim
+
+# VERSION is passed by CI: the git tag for a release, the short SHA otherwise.
+ARG VERSION=dev
+ENV RELEASE=${VERSION} \
+    NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=deps --chown=node:node /src/node_modules ./node_modules
+COPY --chown=node:node package.json ./
+COPY --chown=node:node src ./src
+
+# tsx is a dev dependency, so the runtime image strips types with Node's own
+# loader rather than carrying a TypeScript toolchain into production.
+USER node
+EXPOSE ${{ .Inputs.port }}
+
+CMD ["node", "--experimental-strip-types", "src/server.ts"]

--- a/repo-templates/node-app/skeleton/Makefile
+++ b/repo-templates/node-app/skeleton/Makefile
@@ -1,0 +1,48 @@
+# The CI workflows call `make ci-setup`, `make test`, `make lint` and
+# `make build` and nothing else. That is deliberate: it keeps the workflows
+# identical across every Wayfinder service template, whatever the language.
+# Change how this service is built here, not in .github/workflows/.
+RELEASE ?= dev
+
+.PHONY: all
+all: lint test
+
+# GitHub runners ship Node, so there is no toolchain to install — but the
+# dependencies still need to be there before test or lint can run.
+.PHONY: ci-setup
+ci-setup:
+	node --version
+	npm ci
+
+.PHONY: install
+install:
+	npm install
+
+.PHONY: test
+test:
+	npm test
+
+.PHONY: lint
+lint:
+	npm run typecheck
+	npm run format:check
+
+.PHONY: format
+format:
+	npm run format
+
+.PHONY: build
+build:
+	npm run typecheck
+
+.PHONY: run
+run:
+	npm start
+
+.PHONY: image
+image:
+	docker build --build-arg VERSION=$(RELEASE) -t ${{ .Inputs.serviceName }}:$(RELEASE) .
+
+.PHONY: clean
+clean:
+	rm -rf node_modules

--- a/repo-templates/node-app/skeleton/README.md
+++ b/repo-templates/node-app/skeleton/README.md
@@ -1,0 +1,131 @@
+# ${{ .Inputs.serviceName }}
+
+${{ .Inputs.description }}
+
+Scaffolded by Wayfinder from the `node-app` template.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `src/` | The service. A Fastify server with `/`, `/healthz` and `/readyz`. |
+| `package.json`, `package-lock.json` | Dependencies. |
+| `tsconfig.json` | TypeScript configuration. |
+| `Wayfinder.yaml` | The stack: what gets deployed and what it needs. |
+| `charts/app/` | The Helm chart for the workload. |
+| `plans/` | The CloudResourcePlan backing the storage component. |
+| `.wayfinder/ci.env` | This repository's Wayfinder identity, read by every CI job. |
+| `.github/workflows/` | Pull request previews, deploy to develop, deploy to production. |
+
+## Running it locally
+
+```bash
+make ci-setup # npm ci
+make test     # node:test via tsx
+make lint     # tsc --noEmit and prettier --check
+make run      # start the server on port ${{ .Inputs.port }}
+```
+
+```bash
+curl localhost:${{ .Inputs.port }}/healthz
+curl localhost:${{ .Inputs.port }}/
+```
+
+## Deploying it
+
+CI deploys this service for you. If you want to deploy a copy of your own from
+your laptop, into your own instance:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+wf down -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+```
+
+`wf up` needs an image to run, so pass one that already exists:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER --env-var IMAGE=<registry>/<org>/<repo>:<tag> --env-var RELEASE=local
+```
+
+## How CI works
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `${{ .Inputs.serviceName }}-pr<number>` is deployed in `${{ .Inputs.previewEnvironment }}` and its URL is commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | Tests run, an image tagged `sha-<short sha>` is built, and `${{ .Inputs.serviceName }}-develop` is deployed in `${{ .Inputs.developEnvironment }}`. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `${{ .Inputs.serviceName }}-prod` in `${{ .Inputs.prodEnvironment }}`. |
+
+Cutting a release is therefore:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Where CI configuration lives
+
+Nothing repository-specific is written into the workflow files — they are
+copied verbatim from the template so they stay upgradeable. Configuration
+splits in two:
+
+- **`.wayfinder/ci.env`** — values specific to this repository: the service
+  name, tenant, environments, service accounts and image repository. Add new
+  per-repository values here.
+- **GitHub repository or organisation variables** — values specific to your
+  Wayfinder installation, shared by every repository:
+
+  | Variable | What it is |
+  | --- | --- |
+  | `WF_SERVER` | Wayfinder API URL. |
+  | `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+  | `WF_WORKSPACE` | Workspace to deploy into, when `.wayfinder/ci.env` leaves it blank. |
+  | `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+  | `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+  | `WF_REGION` | Cloud region. |
+  | `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+  | `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides. Each falls back to the value above. |
+  | `WF_PROD_REQUIRE_APPROVAL` | Set to `true` to make production deploys pause for plan approval. |
+  | `WF_EXPECT_INSTANCE_ID` | Guards production against a misconfigured `WF_SERVER`. |
+
+### What CI needs before it can run
+
+Three Wayfinder service accounts, one per environment, each trusting a
+different GitHub OIDC subject so a preview credential cannot reach production:
+
+```bash
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-preview -w <workspace>
+wf create serviceaccountcredential github-preview \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-preview \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-pull-request
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-develop -w <workspace>
+wf create serviceaccountcredential github-develop \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-develop \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment develop
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-prod -w <workspace>
+wf create serviceaccountcredential github-prod \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-prod \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment production
+```
+
+Each needs the `deployer` role in its environment. The preview account also
+needs catalogue write, because `Wayfinder.yaml` refers to its plan as
+`file:plans/...`, which publishes that plan to the workspace catalogue — and
+that happens on a dry run too.
+
+You also need GitHub environments named `develop` and `production` (put your
+reviewers on `production`), and the cluster must be able to pull your image.
+Packages published to GHCR are private by default, so either make the package
+public or give the cluster an image pull secret.
+
+## Storage
+
+`Wayfinder.yaml` provisions an S3 bucket per stack instance and grants this
+service read-write access to it. The bucket name arrives as `BUCKET_NAME`.
+There are no credentials anywhere in this repository: the pod authenticates
+with its own cloud identity, which Wayfinder attaches to its Kubernetes service
+account.
+
+To drop the bucket, remove the `storage` component from `Wayfinder.yaml` along
+with the `workloadIdentity` block and the `env` entries that reference it.

--- a/repo-templates/node-app/skeleton/Wayfinder.yaml
+++ b/repo-templates/node-app/skeleton/Wayfinder.yaml
@@ -1,0 +1,87 @@
+# The Wayfinder stack for this service: what gets deployed, and what it needs.
+#
+# Two things here are filled in when you deploy, not when you edit:
+#
+#   $${{ ... }}  A Wayfinder stack expression. Component outputs, workload
+#               identity annotations and variables are resolved at deploy time.
+#   ${NAME}     Supplied by CI with `wf deploy --env-var NAME=value`. Every one
+#               must resolve, and an --env-var nothing references is rejected.
+#
+# Deploy it yourself with `wf up -i <instance>`; see `wf deploy --help`.
+apiVersion: v1
+name: ${{ .Stack.Name }}
+description: "${{ .Inputs.description }}"
+
+# Deploy-time settings you can vary per environment without editing this file:
+#   wf set var replicas --value 3 -w <workspace> -e prod
+# Values resolve down the tenant > workspace > environment > instance hierarchy.
+vars:
+  - name: replicas
+    description: Number of pods to run.
+    type: number
+    optional: true
+    defaultValue: 1
+
+components:
+${{- if .Inputs.includeStorage }}
+  # An S3 bucket for this service's data, created per stack instance — every
+  # preview, develop and production deployment gets its own.
+  #
+  # This is a provider component: it publishes consumption policies rather than
+  # credentials. The `app` component below is granted one of them, and Wayfinder
+  # turns that grant into the IAM policy on the workload's own identity. No
+  # access keys exist anywhere in this repository.
+  storage:
+    type: CloudResource
+    plan: ${{ .Inputs.storagePlan }}
+    inputs:
+      - name: suffix
+        value: data
+${{ end }}
+  app:
+    type: KubeResource
+${{- if .Inputs.gatewayName }}
+    outputs:
+      - name: url
+        description: Public URL of the service.
+        valueTemplate: "https://$${{ getDNSEntry }}"
+${{- end }}
+${{- if .Inputs.includeStorage }}
+    workloadIdentity:
+      serviceAccountName: ${{ .Inputs.serviceName }}
+      access:
+        - to: storage
+          consumptionPolicy: read-write
+${{- end }}
+    helm:
+      chartPath: charts/app
+      chartName: app
+      valuesTemplate: |
+        image: "${IMAGE}"
+        release: "${RELEASE}"
+        port: ${{ .Inputs.port }}
+        replicas: $${{ .Vars.replicas }}
+        serviceAccount:
+          name: ${{ .Inputs.serviceName }}
+${{- if .Inputs.includeStorage }}
+          annotations:
+        $${{ .WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+        env:
+          BUCKET_NAME: "$${{ .Components.storage.s3_bucket_id }}"
+          BUCKET_ARN: "$${{ .Components.storage.s3_bucket_arn }}"
+${{- end }}
+        httpRoute:
+${{- if .Inputs.gatewayName }}
+          enabled: true
+          hostname: "$${{ getDNSEntry }}"
+          parentGateway:
+            name: ${{ .Inputs.gatewayName }}
+${{- if .Inputs.gatewayNamespace }}
+            namespace: ${{ .Inputs.gatewayNamespace }}
+${{- end }}
+${{- else }}
+          # No Gateway was named when this repository was scaffolded, so the
+          # service is reachable inside the cluster only. To publish it, set
+          # httpRoute.enabled and name a Gateway that exists in this environment.
+          enabled: false
+${{- end }}

--- a/repo-templates/node-app/skeleton/charts/app/Chart.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: The workload for this service, deployed by the Wayfinder stack in Wayfinder.yaml.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/repo-templates/node-app/skeleton/charts/app/templates/_helpers.tpl
+++ b/repo-templates/node-app/skeleton/charts/app/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.serviceAccountName" -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.release | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/repo-templates/node-app/skeleton/charts/app/templates/deployment.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Rolls the pods when the release changes even if the image tag does not.
+        wayfinder.appvia.io/release: {{ .Values.release | quote }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ include "app.name" . }}
+          image: {{ required "image is required; it is supplied by CI as ${IMAGE}" .Values.image | quote }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: RELEASE
+              value: {{ .Values.release | quote }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/repo-templates/node-app/skeleton/charts/app/templates/httproute.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ required "httpRoute.parentGateway.name is required when httpRoute.enabled is true" .Values.httpRoute.parentGateway.name }}
+      {{- with .Values.httpRoute.parentGateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled is true" .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "app.fullname" . }}
+          port: {{ .Values.port }}
+{{- end }}

--- a/repo-templates/node-app/skeleton/charts/app/templates/service.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/repo-templates/node-app/skeleton/charts/app/templates/serviceaccount.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  # Wayfinder puts the cloud workload identity annotations here, which is how
+  # the pod authenticates to its cloud resources without any stored credentials.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/repo-templates/node-app/skeleton/charts/app/values.yaml
+++ b/repo-templates/node-app/skeleton/charts/app/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for a standalone `helm template`. In a real deployment every value
+# here is overwritten by the valuesTemplate in Wayfinder.yaml, which is where
+# the image tag, the workload identity annotations and the storage outputs come
+# from. Edit Wayfinder.yaml, not this file, unless you are adding a new value.
+
+# Container image reference. CI supplies this as ${IMAGE} at deploy time.
+image: ""
+
+# The release this is: a git tag, or sha-<short sha>.
+release: dev
+
+port: 8080
+replicas: 1
+
+serviceAccount:
+  name: app
+  # Wayfinder writes the cloud workload identity annotations here. That is what
+  # lets the pod reach its cloud resources with no credentials in the cluster.
+  annotations: {}
+
+# Environment variables for the container, as a plain name/value map.
+env: {}
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentGateway:
+    name: ""
+    # Leave blank when the Gateway is in this service's own namespace.
+    namespace: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/repo-templates/node-app/skeleton/package-lock.json
+++ b/repo-templates/node-app/skeleton/package-lock.json
@@ -1,0 +1,1221 @@
+{
+  "name": "${{ .Inputs.serviceName }}",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "${{ .Inputs.serviceName }}",
+      "version": "0.1.0",
+      "dependencies": {
+        "fastify": "^5.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "prettier": "^3.4.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.6.tgz",
+      "integrity": "sha512-NtuzM0SfaMJbGlnjr9LWQUN5LzgSrbB8tf/wRZNas+4E1O/Nmzl53e7ruT61HDZyRCJGC6FxIogmNZO1c5ETBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.2.tgz",
+      "integrity": "sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
+      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
+      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.1.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.9.0.tgz",
+      "integrity": "sha512-sJsgZ1sQH2UDuowPuMKg8az7Qc8F0jnj+SKkFWU/+T0xcFlgV5skgXOGUqmQzOdmW6ALA7AhJINWx3qFBkbLHA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/repo-templates/node-app/skeleton/package.json
+++ b/repo-templates/node-app/skeleton/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "${{ .Inputs.serviceName }}",
+  "version": "0.1.0",
+  "description": "${{ .Inputs.description }}",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "dev": "tsx watch src/server.ts",
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "fastify": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "prettier": "^3.4.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/repo-templates/node-app/skeleton/plans/aws-s3-data-bucket.yaml
+++ b/repo-templates/node-app/skeleton/plans/aws-s3-data-bucket.yaml
@@ -1,0 +1,144 @@
+apiVersion: cloudresources/v3
+kind: CloudResourcePlan
+metadata:
+  name: aws-s3-data-bucket
+  version: "1.0.0"
+spec:
+  cloud: aws
+  description: "S3 bucket for application data, with read-only / read-write / write-only consumption policies that other components can be granted."
+  inputs:
+    - name: versioning
+      description: "Enable object versioning. Use with caution — makes deletion harder."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: disable_force_destroy
+      description: "Disable force destroy. Use with caution — teardown will fail while objects remain."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: suffix
+      description: "Differentiates buckets within a stack instance. Combined with stack+instance to form the bucket prefix."
+      type: string
+      optional: true
+      defaultValue: "data"
+
+  # This is a PROVIDER plan: it has no workload identity of its own. Instead it
+  # publishes consumption policies that other components can be granted from the
+  # manifest. Wayfinder turns a grant into the IAM policy below and attaches it to
+  # the consumer's role — no IAM written by hand.
+  consumptionPolicies:
+    - name: read-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: read-write
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadWrite",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: write-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppWriteOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+
+  terraform:
+    modules:
+      - name: s3_bucket
+        source: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+        version: "v4.1.2"
+    files:
+      - name: main.tf
+        template: |
+          module "s3_bucket" {
+            source = ${{ .Modules.s3_bucket.Source | quote }}
+
+            bucket_prefix = "${{ .Stack.Name }}-${{ .Stack.Instance.Name }}-${{ .Inputs.suffix }}-"
+
+            ${{- if .Inputs.versioning }}
+            versioning = {
+              enabled = true
+            }
+            ${{- end }}
+
+            server_side_encryption_configuration = {
+              rule = {
+                apply_server_side_encryption_by_default = {
+                  sse_algorithm = "AES256"
+                }
+              }
+            }
+
+            # AWS blocks public access on new buckets by default; don't attach a
+            # public policy (and avoid s3:PutBucketPublicAccessBlock, which some
+            # account guardrails deny).
+            attach_public_policy = false
+
+            ${{- if not .Inputs.disable_force_destroy }}
+            force_destroy = true
+            ${{- end }}
+
+            tags = {
+              Application = "${{ .Stack.Name }}"
+              Environment = "${{ .Stack.Instance.Name }}"
+              ManagedBy   = "Wayfinder"
+            }
+          }
+      - name: outputs.tf
+        template: |
+          output "s3_bucket_arn" {
+            value = module.s3_bucket.s3_bucket_arn
+          }
+          output "s3_bucket_id" {
+            value = module.s3_bucket.s3_bucket_id
+          }

--- a/repo-templates/node-app/skeleton/src/server.test.ts
+++ b/repo-templates/node-app/skeleton/src/server.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { after, before, describe, it } from 'node:test'
+
+import type { FastifyInstance } from 'fastify'
+
+import { build } from './server.ts'
+
+describe('${{ .Inputs.serviceName }}', () => {
+  let app: FastifyInstance
+
+  before(() => {
+    app = build()
+  })
+
+  after(async () => {
+    await app.close()
+  })
+
+  for (const path of ['/healthz', '/readyz']) {
+    it(`reports ok on ${path}`, async () => {
+      const response = await app.inject({ method: 'GET', url: path })
+
+      assert.equal(response.statusCode, 200)
+      assert.deepEqual(response.json(), { status: 'ok' })
+    })
+  }
+
+  it('reports the service identity on /', async () => {
+    const response = await app.inject({ method: 'GET', url: '/' })
+
+    assert.equal(response.statusCode, 200)
+    const body = response.json()
+    assert.equal(body.service, '${{ .Inputs.serviceName }}')
+    // Always reports something, even 'dev'.
+    assert.ok(body.release)
+  })
+})

--- a/repo-templates/node-app/skeleton/src/server.ts
+++ b/repo-templates/node-app/skeleton/src/server.ts
@@ -1,0 +1,56 @@
+// ${{ .Inputs.description }}
+//
+// Serves three endpoints:
+//
+//   GET /         the service identity and release
+//   GET /healthz  liveness  — is the process alive
+//   GET /readyz   readiness — is the process ready to take traffic
+//
+// The liveness and readiness endpoints are what the Helm chart in charts/app
+// wires up as probes, so keep them cheap and dependency-free.
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// Set at build time by CI: the git tag for a release, the short SHA otherwise,
+// so a running pod can always be traced back to a commit.
+const release = process.env.RELEASE ?? 'dev'
+
+export function build(): FastifyInstance {
+  const app = Fastify({ logger: { level: process.env.LOG_LEVEL ?? 'info' } })
+
+  app.get('/healthz', async () => ({ status: 'ok' }))
+  app.get('/readyz', async () => ({ status: 'ok' }))
+
+  // BUCKET_NAME is set by the Helm chart from the storage component's output.
+  // The workload reaches the bucket through its own cloud identity, so there
+  // are no credentials to read here.
+  app.get('/', async () => ({
+    service: '${{ .Inputs.serviceName }}',
+    release,
+    bucket: process.env.BUCKET_NAME ?? '',
+  }))
+
+  return app
+}
+
+// Only listen when run directly, so importing this from a test does not start
+// a server.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const app = build()
+  const port = Number(process.env.PORT ?? ${{ .Inputs.port }})
+
+  // Shut down on SIGTERM so Kubernetes rolling updates drain in-flight
+  // requests instead of severing them.
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      app.close().then(
+        () => process.exit(0),
+        () => process.exit(1),
+      )
+    })
+  }
+
+  app.listen({ port, host: '0.0.0.0' }).catch((error: unknown) => {
+    app.log.error(error)
+    process.exit(1)
+  })
+}

--- a/repo-templates/node-app/skeleton/tsconfig.json
+++ b/repo-templates/node-app/skeleton/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    // Node strips types at runtime rather than compiling, so imports name the
+    // .ts file they actually resolve to.
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/repo-templates/node-app/wayfinder-template.yaml
+++ b/repo-templates/node-app/wayfinder-template.yaml
@@ -1,0 +1,145 @@
+# Wayfinder repo template definition.
+#
+# Parsed strictly: an unrecognised key here is an error, not a warning.
+# Everything under skeleton/ is what gets written into the new repository.
+name: Node.js Fastify service
+description: >-
+  A TypeScript HTTP service on Fastify, deployed by a Wayfinder stack that runs
+  the app on Kubernetes alongside an S3 bucket it reaches through workload
+  identity. Ships the standard Wayfinder CI set: pull request previews, deploy
+  to develop on merge, and deploy to production on a tag.
+icon: node
+
+inputs:
+  # The only required input. Everything else has a default so the template can
+  # be scaffolded from the catalogue, or from CI with --no-input, by supplying
+  # nothing but a name.
+  - name: serviceName
+    description: >-
+      Name of the service. Used for the Go command package, the container image,
+      the Helm release and the develop and production stack instance names.
+    type: string
+    minLength: 2
+    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+
+  - name: description
+    description: One line describing what this service does.
+    type: string
+    optional: true
+    defaultValue: "A Node.js Fastify service scaffolded by Wayfinder"
+    maxLength: 200
+
+  - name: owner
+    description: Team that owns this service. Written into the README and CODEOWNERS.
+    type: string
+    optional: true
+    defaultValue: ""
+    maxLength: 60
+
+  # The scaffold context has no workspace, so CI needs to be told which one to
+  # deploy into. Leave blank to fall back to the WF_WORKSPACE GitHub variable,
+  # which is the better choice when one workspace serves many repositories.
+  - name: workspace
+    description: >-
+      Wayfinder workspace CI deploys into. Leave blank to take it from the
+      WF_WORKSPACE GitHub repository or organisation variable instead.
+    type: string
+    optional: true
+    defaultValue: ""
+    pattern: "^([a-z][a-z0-9-]*[a-z0-9])?$"
+
+  - name: developEnvironment
+    description: Environment deployed to on every merge to the default branch.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: prodEnvironment
+    description: Environment deployed to when a release tag is pushed.
+    type: string
+    optional: true
+    defaultValue: "prod"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: previewEnvironment
+    description: Environment pull request preview instances are created in.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: registry
+    description: Container registry the service image is published to.
+    type: string
+    optional: true
+    defaultValue: "ghcr.io"
+    enum: ["ghcr.io", "quay.io", "docker.io"]
+
+  - name: port
+    description: TCP port the service listens on.
+    type: number
+    optional: true
+    defaultValue: 8080
+    minimum: 1
+    maximum: 65535
+
+  - name: includeStorage
+    description: >-
+      Provision an S3 bucket alongside the service and grant the workload
+      read-write access to it through workload identity.
+    type: bool
+    optional: true
+    defaultValue: true
+
+  - name: storagePlan
+    description: >-
+      CloudResourcePlan backing the storage component. Defaults to the plan
+      bundled in the generated repository, so the stack deploys with no
+      catalogue prerequisite. Set it to a catalogue reference such as
+      aws-s3-data-bucket@1.0.0 to use your platform team's plan instead.
+    type: string
+    optional: true
+    defaultValue: "file:plans/aws-s3-data-bucket.yaml"
+
+  # Exposing the service needs a Gateway that already exists in the target
+  # environment, which only the platform team knows. With no gateway named, the
+  # service still deploys but is reachable only inside the cluster.
+  - name: gatewayName
+    description: >-
+      Name of an existing Gateway API Gateway to publish the service through.
+      Leave blank to deploy without an HTTPRoute, reachable in-cluster only.
+    type: string
+    optional: true
+    defaultValue: ""
+
+  - name: gatewayNamespace
+    description: >-
+      Namespace of the Gateway named in gatewayName. Leave blank when the
+      Gateway is in the same namespace as the service.
+    type: string
+    optional: true
+    defaultValue: ""
+
+skeleton:
+  path: skeleton
+
+  # Files listed here are copied byte for byte. Their contents are NOT rendered,
+  # so they must not use the `$${{ }}` escape either — it would land literally.
+  #
+  # Note that these globs are matched with path.Match: `**` is not supported, and
+  # `*.yaml` does not match `*.yml`, which is why both are listed.
+  raw:
+    # GitHub Actions has its own ${{ }} expression syntax. Keeping the workflows
+    # raw means they are valid Actions YAML exactly as written, both here and in
+    # the generated repository. Per-repository values reach them through
+    # .wayfinder/ci.env, which is rendered.
+    - ".github/workflows/*.yaml"
+    - ".github/workflows/*.yml"
+    - ".wayfinder/*.sh"
+    # Helm charts are Helm templating, evaluated at deploy time, not now.
+    - "charts/app/*"
+    - "charts/app/templates/*"
+    # CloudResourcePlans use the Wayfinder stack template engine, not this one.
+    - "plans/*.yaml"

--- a/repo-templates/python-app/README.md
+++ b/repo-templates/python-app/README.md
@@ -1,0 +1,72 @@
+# Python FastAPI service template
+
+A Python HTTP service on FastAPI, managed with uv, with a Wayfinder stack that
+runs it on Kubernetes alongside an S3 bucket it reaches through workload
+identity.
+
+This directory is the template definition. It is not itself a Python project —
+the project lives under `skeleton/`, and only that is written into a new
+repository.
+
+| File | What it is |
+| --- | --- |
+| `wayfinder-template.yaml` | The template: its inputs, and which files are copied raw. |
+| `RepoTemplate-python-app.yaml` | Registers the template with Wayfinder. |
+| `skeleton/` | Everything written into the generated repository. |
+
+## Using it
+
+```bash
+wf apply -f RepoTemplate-python-app.yaml
+wf create stack payments --from-template python-app --input serviceName=payments --dry-run
+```
+
+Drop `--dry-run` and add `--github-org` and `--workspace` to create the
+repository for real. See [../DELIVERY-PIPELINE.md](../DELIVERY-PIPELINE.md) for what CI does and what it needs first.
+
+## What the generated repository contains
+
+```
+payments/
+├── README.md
+├── Wayfinder.yaml              app + S3 bucket, wired by workload identity
+├── Makefile                    ci-setup / test / lint / build — what CI calls
+├── Dockerfile                  uv-built venv on python:3.13-slim, non-root
+├── pyproject.toml, uv.lock
+├── app/                        __init__.py, main.py
+├── tests/                      test_main.py
+├── charts/app/                 the workload chart
+├── plans/                      the CloudResourcePlan for the bucket
+├── .wayfinder/                 ci.env (this repo's identity) + ci-env.sh
+└── .github/workflows/          ci · preview teardown · deploy develop · deploy prod
+```
+
+## Inputs
+
+`serviceName` is the only required one. It is used for the package name,
+the image name, the Helm release and the stack instance names.
+
+Everything else is optional and defaulted, so `--input serviceName=payments
+--no-input` is enough to scaffold from CI. The two worth setting deliberately:
+
+- `gatewayName` — name an existing Gateway API Gateway to publish the service.
+  Left blank, the service deploys but is reachable in-cluster only.
+- `workspace` — leave blank to take the workspace from the `WF_WORKSPACE`
+  GitHub variable instead, which is better when one workspace serves many
+  repositories.
+
+Run `wf get repotemplate python-app -o yaml` to see the full list with defaults.
+
+## Editing this template
+
+- **`skeleton/.github/workflows/*` and `skeleton/charts/**` are raw.** They are
+  copied byte for byte and never rendered, so they must not contain `${{ }}` or
+  `$${{ }}` meant for the scaffolder. Per-repository values belong in
+  `skeleton/.wayfinder/ci.env`, which is rendered.
+- **`skeleton/Wayfinder.yaml` is rendered and mixes two engines.** Every
+  Wayfinder *stack* expression in it must be written `$${{ ... }}` so it
+  survives scaffolding as a literal `${{ ... }}`. Getting this wrong fails at
+  the moment someone creates a repository, so check it with `--dry-run`.
+- The workflows are shared across all four templates in this repository. Edit
+  `../_shared/workflows/`, copy the result into every template, and CI will
+  check they match.

--- a/repo-templates/python-app/README.md
+++ b/repo-templates/python-app/README.md
@@ -4,6 +4,10 @@ A Python HTTP service on FastAPI, managed with uv, with a Wayfinder stack that
 runs it on Kubernetes alongside an S3 bucket it reaches through workload
 identity.
 
+`RepoTemplate-python-app.yaml` is the object you give Wayfinder — a pointer at this
+directory. `wayfinder-template.yaml` is the template itself, which Wayfinder
+reads once it has followed that pointer. See [../ANATOMY.md](../ANATOMY.md).
+
 This directory is the template definition. It is not itself a Python project —
 the project lives under `skeleton/`, and only that is written into a new
 repository.

--- a/repo-templates/python-app/RepoTemplate-python-app.yaml
+++ b/repo-templates/python-app/RepoTemplate-python-app.yaml
@@ -1,0 +1,30 @@
+# Registers the Python FastAPI service template with Wayfinder.
+#
+# This repository is public, so Wayfinder reads the template anonymously — no
+# GitHub connection is needed to register it or to preview what it renders.
+# Creating a repository from it does need a connected GitHub organisation.
+#
+#   wf apply -f RepoTemplate-python-app.yaml
+#   wf get repotemplate python-app -o yaml     # check status.manifest synced
+#   wf create stack payments --from-template python-app --input serviceName=payments --dry-run
+#
+apiVersion: sourcecontrol/v3
+kind: RepoTemplate
+metadata:
+  name: python-app
+  # Free-form axes for filtering the catalogue. Classification is spec.category.
+  labels:
+    language: python
+    framework: fastapi
+    family: wayfinder-golden-path
+spec:
+  url: https://github.com/appvia/wayfinder-examples.git
+  # The directory holding wayfinder-template.yaml. One repository can host many
+  # templates, each registered separately.
+  path: repo-templates/python-app
+  # Branch or tag to read. Pin this to a tag to hold the template steady —
+  # tracking a branch means every merge changes the template for everyone on the
+  # next resync. Point it at a branch to try a change before merging it.
+  ref: main
+  displayName: Python FastAPI service
+  category: service

--- a/repo-templates/python-app/skeleton/.dockerignore
+++ b/repo-templates/python-app/skeleton/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.wayfinder
+.venv
+charts
+plans
+dist
+tests
+.pytest_cache
+.ruff_cache
+__pycache__
+Wayfinder.yaml
+wayfinder-stack.yaml
+README.md

--- a/repo-templates/python-app/skeleton/.github/dependabot.yml
+++ b/repo-templates/python-app/skeleton/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Keeps this repository current on its own, rather than relying on the template
+# it was scaffolded from being re-run.
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/repo-templates/python-app/skeleton/.github/workflows/ci.yaml
+++ b/repo-templates/python-app/skeleton/.github/workflows/ci.yaml
@@ -1,0 +1,201 @@
+# Pull request checks.
+#
+# Tests the code, builds a container image, validates the stack against
+# Wayfinder without applying anything, then deploys a throwaway preview
+# instance and comments its URL on the pull request. The preview is destroyed
+# by wf-preview-teardown.yaml when the pull request closes.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it, so you can edit it like any other workflow. Values that differ
+# per repository live in .wayfinder/ci.env; values that differ per Wayfinder
+# installation are GitHub repository or organisation variables. Add new values
+# to one of those, not to this file.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write # lets GitHub mint the OIDC token Wayfinder authenticates with
+
+# Runs for one pull request are serialised rather than cancelled: a cancelled
+# `wf deploy` can leave a half-applied stack and orphaned cloud resources.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          # GITHUB_TOKEN covers ghcr.io. For any other registry, set the
+          # REGISTRY_USERNAME variable and REGISTRY_PASSWORD secret.
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  validate:
+    name: Validate stack
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      # Plans the deployment server-side and applies none of it. Note that when
+      # Wayfinder.yaml refers to a plan as `file:plans/...`, that plan IS
+      # published to the workspace catalogue even on a dry run, so the service
+      # account needs catalogue write as well as deploy rights.
+      - name: Validate the stack
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --dry-run --non-interactive \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${WF_IMAGE_REPO}:validate" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            "${args[@]}"
+
+  preview:
+    name: Preview environment
+    needs: [test, build, validate]
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy the preview instance
+        id: deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="pr-${{ github.event.pull_request.number }}" \
+            --label "preview:pr-${{ github.event.pull_request.number }}" \
+            --out-file ./preview.json \
+            "${args[@]}"
+          echo "url=$(jq -r '.componentOutputs.app.url.value // empty' ./preview.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL on the pull request
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_INSTANCE: ${{ env.WF_INSTANCE }}
+          PREVIEW_ENVIRONMENT: ${{ env.WAYFINDER_ENVIRONMENT }}
+        with:
+          script: |
+            const info = {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }
+            const marker = '<!-- wayfinder-preview -->'
+            const url = process.env.PREVIEW_URL
+            const headline = url
+              ? `**${url}**`
+              : '_Deployed, but the stack published no `url` output._'
+            const body = [
+              marker,
+              '### Wayfinder preview environment',
+              '',
+              headline,
+              '',
+              `<sub>Instance \`${process.env.PREVIEW_INSTANCE}\` in environment ` +
+                `\`${process.env.PREVIEW_ENVIRONMENT}\` · commit ${context.sha.substring(0, 7)} · ` +
+                'destroyed automatically when this pull request closes.</sub>',
+            ].join('\n')
+
+            for (const comment of (await github.rest.issues.listComments(info)).data) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.rest.issues.updateComment({ ...info, comment_id: comment.id, body })
+                return
+              }
+            }
+            await github.rest.issues.createComment({ ...info, body })

--- a/repo-templates/python-app/skeleton/.github/workflows/wf-deploy-develop.yaml
+++ b/repo-templates/python-app/skeleton/.github/workflows/wf-deploy-develop.yaml
@@ -1,0 +1,130 @@
+# Deploys to the develop environment on every merge to the default branch.
+#
+# The image is tagged with the commit SHA, so every develop deployment is
+# traceable to exactly one commit.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env; per-installation
+# values are GitHub repository or organisation variables.
+name: Deploy to develop
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Scopes the OIDC token to `repo:<owner>/<repo>:environment:develop`, which
+    # is what the develop service account credential trusts.
+    environment: develop
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh develop
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE }}
+
+      - name: Deploy
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+          wf deploy --non-interactive --timeout 30m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="sha-${GITHUB_SHA:0:7}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Deployed to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}

--- a/repo-templates/python-app/skeleton/.github/workflows/wf-deploy-prod.yaml
+++ b/repo-templates/python-app/skeleton/.github/workflows/wf-deploy-prod.yaml
@@ -1,0 +1,201 @@
+# Deploys a tagged release to production.
+#
+# Every job checks out the tag rather than the branch head, so the image, the
+# tests and the Wayfinder.yaml that is deployed all come from the tagged tree.
+# The image is tagged with the release tag and that exact tag is what production
+# runs.
+#
+# There are two independent gates:
+#
+#   1. `environment: production` — GitHub's own gate. Configure reviewers and
+#      wait timers on the environment. It also scopes the OIDC token to
+#      `repo:<owner>/<repo>:environment:production`, which is what the
+#      production service account credential trusts, so the gate is enforced by
+#      the token, not only by the UI.
+#
+#   2. `--require-approval` — Wayfinder's gate on the infrastructure plan. Each
+#      CloudResource is planned and pauses for approval. Opt in by setting the
+#      WF_PROD_REQUIRE_APPROVAL variable to `true`.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Deploy to production
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Each template implements ci-setup for whatever its language needs —
+      # nothing, or installing a tool the runner does not ship. It is what keeps
+      # this workflow identical across every Wayfinder service template.
+      - name: Set up the toolchain
+        run: make ci-setup
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+  build:
+    name: Build image
+    needs: [test]
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Load repository configuration
+        # $GITHUB_ENV accepts KEY=value lines only, so comments are filtered out.
+        run: grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env >> "$GITHUB_ENV"
+
+      - name: Compute the image reference
+        id: meta
+        env:
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "image=${WF_IMAGE_REPO}:${RELEASE}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.WF_IMAGE_REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: production
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh prod
+        env:
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+          # Production may live on a different cluster, identity or DNS zone.
+          # Each falls back to the shared value when no _PROD override is set.
+          WF_HOST_CLUSTER: ${{ vars.WF_HOST_CLUSTER_PROD || vars.WF_HOST_CLUSTER }}
+          WF_IDENTITY: ${{ vars.WF_IDENTITY_PROD || vars.WF_IDENTITY }}
+          WF_REGION: ${{ vars.WF_REGION_PROD || vars.WF_REGION }}
+          WF_DNS_ZONE: ${{ vars.WF_DNS_ZONE_PROD || vars.WF_DNS_ZONE }}
+
+      - name: Verify the Wayfinder identity
+        run: wf whoami
+
+      # Guards against a misconfigured WF_SERVER pointing production traffic at
+      # the wrong Wayfinder installation. Set WF_EXPECT_INSTANCE_ID to the value
+      # of `wf serverinfo -o json | jq -r .instanceIdentifier` for production.
+      - name: Verify the Wayfinder installation
+        if: vars.WF_EXPECT_INSTANCE_ID != ''
+        env:
+          EXPECTED: ${{ vars.WF_EXPECT_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+          actual="$(wf serverinfo -o json | jq -r .instanceIdentifier)"
+          if [[ "${actual}" != "${EXPECTED}" ]]; then
+            echo "::error::Expected Wayfinder installation '${EXPECTED}' but this is '${actual}'. Nothing was deployed."
+            exit 1
+          fi
+
+      - name: Deploy the release
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+          REQUIRE_APPROVAL: ${{ vars.WF_PROD_REQUIRE_APPROVAL }}
+          APPROVAL_TIMEOUT: ${{ vars.WF_PROD_APPROVAL_TIMEOUT }}
+        run: |
+          set -euo pipefail
+          mapfile -t args < "${WF_DEPLOY_ARGS_FILE}"
+
+          if [[ "${REQUIRE_APPROVAL:-false}" == "true" ]]; then
+            args+=("--require-approval")
+            if [[ -n "${APPROVAL_TIMEOUT:-}" ]]; then
+              args+=("--approval-timeout" "${APPROVAL_TIMEOUT}")
+            fi
+          fi
+
+          set +e
+          wf deploy --non-interactive --timeout 45m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            -f Wayfinder.yaml \
+            --env-var IMAGE="${IMAGE}" \
+            --env-var RELEASE="${RELEASE}" \
+            --out-file ./deploy.json \
+            "${args[@]}"
+          rc=$?
+          set -e
+
+          # Exit code 3 means an approval gate was not decided in time. Nothing
+          # was applied — this is not a failed deployment, and re-running the
+          # job once the plan is approved is the correct next step. Anything
+          # else is a real failure.
+          if [[ ${rc} -eq 3 ]]; then
+            echo "::error title=Awaiting approval::Deployment of ${RELEASE} is paused at a Wayfinder approval gate and the approval window elapsed. Nothing has been applied. Approve the plan with 'wf approve cloudresource', then re-run this job."
+            {
+              echo "### :hourglass: ${RELEASE} is awaiting approval"
+              echo ""
+              echo "No changes were applied. Review the plan above, approve it with"
+              echo "\`wf approve cloudresource <name> -w ${WAYFINDER_WORKSPACE} -e ${WAYFINDER_ENVIRONMENT}\`,"
+              echo "then re-run this job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 3
+          fi
+          exit ${rc}
+
+      - name: Summarise
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          RELEASE: ${{ github.ref_name }}
+        run: |
+          {
+            echo "### Released ${RELEASE} to ${WAYFINDER_ENVIRONMENT}"
+            echo ""
+            echo "- Instance: \`${WF_INSTANCE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- URL: $(jq -r '.componentOutputs.app.url.value // "no url output"' ./deploy.json)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/repo-templates/python-app/skeleton/.github/workflows/wf-preview-teardown.yaml
+++ b/repo-templates/python-app/skeleton/.github/workflows/wf-preview-teardown.yaml
@@ -1,0 +1,46 @@
+# Destroys the preview environment when a pull request closes.
+#
+# Runs whether the pull request was merged or abandoned — `closed` covers both.
+#
+# This file is copied into your repository verbatim — Wayfinder does not
+# template it. Per-repository values live in .wayfinder/ci.env.
+name: Tear down preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Destroy preview instance
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.WF_TOOLBOX_IMAGE || 'quay.io/appvia-wayfinder/wftoolbox:latest' }}
+    env:
+      WAYFINDER_SERVER: ${{ vars.WF_SERVER }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve the Wayfinder context
+        run: .wayfinder/ci-env.sh preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WF_WORKSPACE_VAR: ${{ vars.WF_WORKSPACE }}
+
+      # Tolerates an instance that was never created: a pull request can be
+      # closed before any preview deployed, and a failed teardown must not turn
+      # a merged pull request red.
+      - name: Destroy the preview instance
+        run: |
+          wf down --non-interactive --timeout 20m \
+            -i "${WF_INSTANCE}" \
+            -e "${WAYFINDER_ENVIRONMENT}" \
+            || echo "::warning::Teardown of ${WF_INSTANCE} did not complete. Check for leftover resources with 'wf get stackinstance ${WF_INSTANCE} -e ${WAYFINDER_ENVIRONMENT}'."

--- a/repo-templates/python-app/skeleton/.gitignore
+++ b/repo-templates/python-app/skeleton/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+dist/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+
+# Written by `wf up` to remember the stack instance you last deployed to.
+.wfup

--- a/repo-templates/python-app/skeleton/.wayfinder/ci-env.sh
+++ b/repo-templates/python-app/skeleton/.wayfinder/ci-env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Resolves the Wayfinder context for one CI stage and exports it to the job.
+#
+#   usage: .wayfinder/ci-env.sh <preview|develop|prod>
+#
+# Reads .wayfinder/ci.env, which Wayfinder wrote when this repository was
+# scaffolded, combines it with the WF_* GitHub variables set on the repository
+# or organisation, and writes the result to $GITHUB_ENV so later steps can use
+# it directly. Deployment target flags are written one per line to a file whose
+# path lands in WF_DEPLOY_ARGS_FILE; read them with `mapfile -t args < "$FILE"`.
+#
+# Exports:
+#   WAYFINDER_TENANT, WAYFINDER_WORKSPACE, WAYFINDER_ENVIRONMENT
+#   WAYFINDER_SERVICE_ACCOUNT  the CLI authenticates with this implicitly
+#   WF_INSTANCE                the stack instance for this stage
+#   WF_DEPLOY_ARGS_FILE        --target/--identity/--region/--dns-zone flags
+#   plus everything in .wayfinder/ci.env
+set -euo pipefail
+
+stage="${1:-}"
+if [[ -z "${stage}" ]]; then
+  echo "::error::usage: .wayfinder/ci-env.sh <preview|develop|prod>"
+  exit 1
+fi
+
+# shellcheck source=ci.env disable=SC1091
+source .wayfinder/ci.env
+
+case "${stage}" in
+  preview)
+    if [[ -z "${PR_NUMBER:-}" ]]; then
+      echo "::error::PR_NUMBER must be set for the preview stage."
+      exit 1
+    fi
+    environment="${WF_ENV_PREVIEW}"
+    account="${WF_SA_PREVIEW}"
+    instance="${WF_SERVICE_NAME}-pr${PR_NUMBER}"
+    ;;
+  develop)
+    environment="${WF_ENV_DEVELOP}"
+    account="${WF_SA_DEVELOP}"
+    instance="${WF_INSTANCE_DEVELOP}"
+    ;;
+  prod)
+    environment="${WF_ENV_PROD}"
+    account="${WF_SA_PROD}"
+    instance="${WF_INSTANCE_PROD}"
+    ;;
+  *)
+    echo "::error::Unknown stage '${stage}'. Expected preview, develop or prod."
+    exit 1
+    ;;
+esac
+
+# The workspace is a scaffold-time input. Where it was left blank, fall back to
+# the WF_WORKSPACE repository or organisation variable, which is the better
+# place for it when one workspace serves many repositories.
+workspace="${WF_WORKSPACE:-${WF_WORKSPACE_VAR:-}}"
+if [[ -z "${workspace}" ]]; then
+  echo "::error::No Wayfinder workspace. Set the WF_WORKSPACE repository or organisation variable."
+  exit 1
+fi
+
+args_file="${RUNNER_TEMP:-/tmp}/wf-deploy-args"
+: >"${args_file}"
+
+# A cluster in the workspace and environment already selected above, narrowed to
+# a namespace named after the instance so each deployment is isolated.
+if [[ -n "${WF_HOST_CLUSTER:-}" ]]; then
+  printf '%s\n' "--target" "k8s:${WF_HOST_CLUSTER}:${instance}" >>"${args_file}"
+fi
+# The cloud identity Wayfinder provisions cloud resources through. Wayfinder
+# reads the account it reaches, so no separate --target is needed for the cloud.
+if [[ -n "${WF_IDENTITY:-}" ]]; then
+  printf '%s\n' "--identity" "${WF_IDENTITY}" >>"${args_file}"
+fi
+if [[ -n "${WF_REGION:-}" ]]; then
+  printf '%s\n' "--region" "${WF_REGION}" >>"${args_file}"
+fi
+if [[ -n "${WF_DNS_ZONE:-}" ]]; then
+  printf '%s\n' "--dns-zone" "${WF_DNS_ZONE}" >>"${args_file}"
+fi
+
+{
+  # $GITHUB_ENV accepts KEY=value lines only, so the comments in ci.env are
+  # filtered out rather than passed through.
+  grep -E '^[A-Z][A-Z0-9_]*=' .wayfinder/ci.env
+  echo "WF_INSTANCE=${instance}"
+  echo "WF_DEPLOY_ARGS_FILE=${args_file}"
+  echo "WAYFINDER_TENANT=${WF_TENANT}"
+  echo "WAYFINDER_WORKSPACE=${workspace}"
+  echo "WAYFINDER_ENVIRONMENT=${environment}"
+  echo "WAYFINDER_SERVICE_ACCOUNT=${WF_TENANT}:${workspace}:${account}"
+} >>"${GITHUB_ENV:?GITHUB_ENV is not set; this script is meant to run in GitHub Actions}"
+
+echo "Stage ${stage}: instance ${instance} in ${WF_TENANT}:${workspace}:${environment}"
+echo "Deploying as service account ${WF_TENANT}:${workspace}:${account}"

--- a/repo-templates/python-app/skeleton/.wayfinder/ci.env
+++ b/repo-templates/python-app/skeleton/.wayfinder/ci.env
@@ -1,0 +1,36 @@
+# Wayfinder wrote this file when it created this repository.
+#
+# It holds the values that identify THIS repository to Wayfinder. Every CI job
+# loads it, so this is where to add a new per-repository value — the workflows
+# themselves are copied verbatim from the template and carry no repository
+# specifics.
+#
+# Values that differ per Wayfinder installation rather than per repository
+# (server URL, host cluster, cloud identity, DNS zone) are GitHub repository or
+# organisation variables instead. See .github/workflows/ and the template README.
+
+# Identity
+WF_SERVICE_NAME=${{ .Inputs.serviceName }}
+WF_TENANT=${{ .Tenant }}
+# Blank means "use the WF_WORKSPACE GitHub variable".
+WF_WORKSPACE=${{ .Inputs.workspace }}
+WF_APP_PORT=${{ .Inputs.port }}
+
+# Environments
+WF_ENV_PREVIEW=${{ .Inputs.previewEnvironment }}
+WF_ENV_DEVELOP=${{ .Inputs.developEnvironment }}
+WF_ENV_PROD=${{ .Inputs.prodEnvironment }}
+
+# Stack instances. Preview instances are named <service>-pr<number> at run time.
+WF_INSTANCE_DEVELOP=${{ .Inputs.serviceName }}-develop
+WF_INSTANCE_PROD=${{ .Inputs.serviceName }}-prod
+
+# Service accounts, one per environment, so a leaked preview credential cannot
+# deploy to production. Each is <tenant>:<workspace>:<name> at run time.
+WF_SA_PREVIEW=${{ .Inputs.serviceName }}-ci-preview
+WF_SA_DEVELOP=${{ .Inputs.serviceName }}-ci-develop
+WF_SA_PROD=${{ .Inputs.serviceName }}-ci-prod
+
+# Container image
+WF_IMAGE_REGISTRY=${{ .Inputs.registry }}
+WF_IMAGE_REPO=${{ .Inputs.registry }}/${{ .Repo.Organization }}/${{ .Repo.Name }}

--- a/repo-templates/python-app/skeleton/Dockerfile
+++ b/repo-templates/python-app/skeleton/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build -----------------------------------------------------------------
+FROM python:3.13-slim AS build
+
+# renovate: datasource=github-releases depName=astral-sh/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /src
+
+# Dependencies first, so a source-only change reuses the cached layer.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-dev --no-install-project
+
+COPY app ./app
+RUN uv sync --locked --no-dev
+
+# ---- Run -------------------------------------------------------------------
+FROM python:3.13-slim
+
+# VERSION is passed by CI: the git tag for a release, the short SHA otherwise.
+ARG VERSION=dev
+ENV RELEASE=${VERSION} \
+    PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN useradd --create-home --uid 10001 app
+WORKDIR /app
+
+COPY --from=build --chown=app:app /src/.venv /app/.venv
+COPY --chown=app:app app ./app
+
+USER app
+EXPOSE ${{ .Inputs.port }}
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-${{ .Inputs.port }}}"]

--- a/repo-templates/python-app/skeleton/Makefile
+++ b/repo-templates/python-app/skeleton/Makefile
@@ -1,0 +1,49 @@
+# The CI workflows call `make ci-setup`, `make test`, `make lint` and
+# `make build` and nothing else. That is deliberate: it keeps the workflows
+# identical across every Wayfinder service template, whatever the language.
+# Change how this service is built here, not in .github/workflows/.
+RELEASE ?= dev
+
+.PHONY: all
+all: lint test
+
+# GitHub runners ship Python but not uv, and uv manages the interpreter as well
+# as the dependencies, so installing it is all the bootstrap this needs.
+.PHONY: ci-setup
+ci-setup:
+	@command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+	uv --version
+
+.PHONY: install
+install:
+	uv sync --locked
+
+.PHONY: test
+test: install
+	uv run pytest -q
+
+.PHONY: lint
+lint: install
+	uv run ruff check .
+	uv run ruff format --check .
+
+.PHONY: format
+format: install
+	uv run ruff format .
+	uv run ruff check --fix .
+
+.PHONY: build
+build: install
+	uv build
+
+.PHONY: run
+run: install
+	uv run uvicorn app.main:app --reload --port ${{ .Inputs.port }}
+
+.PHONY: image
+image:
+	docker build --build-arg VERSION=$(RELEASE) -t ${{ .Inputs.serviceName }}:$(RELEASE) .
+
+.PHONY: clean
+clean:
+	rm -rf .venv dist .pytest_cache .ruff_cache

--- a/repo-templates/python-app/skeleton/README.md
+++ b/repo-templates/python-app/skeleton/README.md
@@ -1,0 +1,131 @@
+# ${{ .Inputs.serviceName }}
+
+${{ .Inputs.description }}
+
+Scaffolded by Wayfinder from the `python-app` template.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `app/` | The service. A FastAPI app with `/`, `/healthz` and `/readyz`. |
+| `tests/` | The pytest suite. |
+| `pyproject.toml`, `uv.lock` | Dependencies, managed with uv. |
+| `Wayfinder.yaml` | The stack: what gets deployed and what it needs. |
+| `charts/app/` | The Helm chart for the workload. |
+| `plans/` | The CloudResourcePlan backing the storage component. |
+| `.wayfinder/ci.env` | This repository's Wayfinder identity, read by every CI job. |
+| `.github/workflows/` | Pull request previews, deploy to develop, deploy to production. |
+
+## Running it locally
+
+```bash
+make ci-setup # install uv, if you do not have it
+make test     # pytest
+make lint     # ruff check and ruff format --check
+make run      # start uvicorn with reload on port ${{ .Inputs.port }}
+```
+
+```bash
+curl localhost:${{ .Inputs.port }}/healthz
+curl localhost:${{ .Inputs.port }}/
+```
+
+## Deploying it
+
+CI deploys this service for you. If you want to deploy a copy of your own from
+your laptop, into your own instance:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+wf down -i ${{ .Inputs.serviceName }}-$USER -e ${{ .Inputs.developEnvironment }}
+```
+
+`wf up` needs an image to run, so pass one that already exists:
+
+```bash
+wf up -i ${{ .Inputs.serviceName }}-$USER --env-var IMAGE=<registry>/<org>/<repo>:<tag> --env-var RELEASE=local
+```
+
+## How CI works
+
+| When | What happens |
+| --- | --- |
+| Pull request opened or pushed to | Tests run, an image is built, the stack is validated with a dry run, then a preview instance `${{ .Inputs.serviceName }}-pr<number>` is deployed in `${{ .Inputs.previewEnvironment }}` and its URL is commented on the pull request. |
+| Pull request closed | The preview instance is destroyed, merged or not. |
+| Merge to `main` | Tests run, an image tagged `sha-<short sha>` is built, and `${{ .Inputs.serviceName }}-develop` is deployed in `${{ .Inputs.developEnvironment }}`. |
+| Tag `v*` pushed | The tagged tree is tested and built as `<image>:<tag>`, and that exact tag is deployed to `${{ .Inputs.serviceName }}-prod` in `${{ .Inputs.prodEnvironment }}`. |
+
+Cutting a release is therefore:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Where CI configuration lives
+
+Nothing repository-specific is written into the workflow files — they are
+copied verbatim from the template so they stay upgradeable. Configuration
+splits in two:
+
+- **`.wayfinder/ci.env`** — values specific to this repository: the service
+  name, tenant, environments, service accounts and image repository. Add new
+  per-repository values here.
+- **GitHub repository or organisation variables** — values specific to your
+  Wayfinder installation, shared by every repository:
+
+  | Variable | What it is |
+  | --- | --- |
+  | `WF_SERVER` | Wayfinder API URL. |
+  | `WF_TOOLBOX_IMAGE` | Image providing the `wf` CLI. Defaults to `quay.io/appvia-wayfinder/wftoolbox:latest`. |
+  | `WF_WORKSPACE` | Workspace to deploy into, when `.wayfinder/ci.env` leaves it blank. |
+  | `WF_HOST_CLUSTER` | Cluster to deploy the workload to. |
+  | `WF_IDENTITY` | Cloud identity Wayfinder provisions cloud resources through. |
+  | `WF_REGION` | Cloud region. |
+  | `WF_DNS_ZONE` | DNS zone the service hostname is allocated from. |
+  | `WF_HOST_CLUSTER_PROD`, `WF_IDENTITY_PROD`, `WF_REGION_PROD`, `WF_DNS_ZONE_PROD` | Production overrides. Each falls back to the value above. |
+  | `WF_PROD_REQUIRE_APPROVAL` | Set to `true` to make production deploys pause for plan approval. |
+  | `WF_EXPECT_INSTANCE_ID` | Guards production against a misconfigured `WF_SERVER`. |
+
+### What CI needs before it can run
+
+Three Wayfinder service accounts, one per environment, each trusting a
+different GitHub OIDC subject so a preview credential cannot reach production:
+
+```bash
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-preview -w <workspace>
+wf create serviceaccountcredential github-preview \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-preview \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-pull-request
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-develop -w <workspace>
+wf create serviceaccountcredential github-develop \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-develop \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment develop
+
+wf create serviceaccount ${{ .Inputs.serviceName }}-ci-prod -w <workspace>
+wf create serviceaccountcredential github-prod \
+  --service-account <tenant>:<workspace>:${{ .Inputs.serviceName }}-ci-prod \
+  --github-repo ${{ .Repo.Organization }}/${{ .Repo.Name }} --github-environment production
+```
+
+Each needs the `deployer` role in its environment. The preview account also
+needs catalogue write, because `Wayfinder.yaml` refers to its plan as
+`file:plans/...`, which publishes that plan to the workspace catalogue — and
+that happens on a dry run too.
+
+You also need GitHub environments named `develop` and `production` (put your
+reviewers on `production`), and the cluster must be able to pull your image.
+Packages published to GHCR are private by default, so either make the package
+public or give the cluster an image pull secret.
+
+## Storage
+
+`Wayfinder.yaml` provisions an S3 bucket per stack instance and grants this
+service read-write access to it. The bucket name arrives as `BUCKET_NAME`.
+There are no credentials anywhere in this repository: the pod authenticates
+with its own cloud identity, which Wayfinder attaches to its Kubernetes service
+account.
+
+To drop the bucket, remove the `storage` component from `Wayfinder.yaml` along
+with the `workloadIdentity` block and the `env` entries that reference it.

--- a/repo-templates/python-app/skeleton/Wayfinder.yaml
+++ b/repo-templates/python-app/skeleton/Wayfinder.yaml
@@ -1,0 +1,87 @@
+# The Wayfinder stack for this service: what gets deployed, and what it needs.
+#
+# Two things here are filled in when you deploy, not when you edit:
+#
+#   $${{ ... }}  A Wayfinder stack expression. Component outputs, workload
+#               identity annotations and variables are resolved at deploy time.
+#   ${NAME}     Supplied by CI with `wf deploy --env-var NAME=value`. Every one
+#               must resolve, and an --env-var nothing references is rejected.
+#
+# Deploy it yourself with `wf up -i <instance>`; see `wf deploy --help`.
+apiVersion: v1
+name: ${{ .Stack.Name }}
+description: "${{ .Inputs.description }}"
+
+# Deploy-time settings you can vary per environment without editing this file:
+#   wf set var replicas --value 3 -w <workspace> -e prod
+# Values resolve down the tenant > workspace > environment > instance hierarchy.
+vars:
+  - name: replicas
+    description: Number of pods to run.
+    type: number
+    optional: true
+    defaultValue: 1
+
+components:
+${{- if .Inputs.includeStorage }}
+  # An S3 bucket for this service's data, created per stack instance — every
+  # preview, develop and production deployment gets its own.
+  #
+  # This is a provider component: it publishes consumption policies rather than
+  # credentials. The `app` component below is granted one of them, and Wayfinder
+  # turns that grant into the IAM policy on the workload's own identity. No
+  # access keys exist anywhere in this repository.
+  storage:
+    type: CloudResource
+    plan: ${{ .Inputs.storagePlan }}
+    inputs:
+      - name: suffix
+        value: data
+${{ end }}
+  app:
+    type: KubeResource
+${{- if .Inputs.gatewayName }}
+    outputs:
+      - name: url
+        description: Public URL of the service.
+        valueTemplate: "https://$${{ getDNSEntry }}"
+${{- end }}
+${{- if .Inputs.includeStorage }}
+    workloadIdentity:
+      serviceAccountName: ${{ .Inputs.serviceName }}
+      access:
+        - to: storage
+          consumptionPolicy: read-write
+${{- end }}
+    helm:
+      chartPath: charts/app
+      chartName: app
+      valuesTemplate: |
+        image: "${IMAGE}"
+        release: "${RELEASE}"
+        port: ${{ .Inputs.port }}
+        replicas: $${{ .Vars.replicas }}
+        serviceAccount:
+          name: ${{ .Inputs.serviceName }}
+${{- if .Inputs.includeStorage }}
+          annotations:
+        $${{ .WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+        env:
+          BUCKET_NAME: "$${{ .Components.storage.s3_bucket_id }}"
+          BUCKET_ARN: "$${{ .Components.storage.s3_bucket_arn }}"
+${{- end }}
+        httpRoute:
+${{- if .Inputs.gatewayName }}
+          enabled: true
+          hostname: "$${{ getDNSEntry }}"
+          parentGateway:
+            name: ${{ .Inputs.gatewayName }}
+${{- if .Inputs.gatewayNamespace }}
+            namespace: ${{ .Inputs.gatewayNamespace }}
+${{- end }}
+${{- else }}
+          # No Gateway was named when this repository was scaffolded, so the
+          # service is reachable inside the cluster only. To publish it, set
+          # httpRoute.enabled and name a Gateway that exists in this environment.
+          enabled: false
+${{- end }}

--- a/repo-templates/python-app/skeleton/app/__init__.py
+++ b/repo-templates/python-app/skeleton/app/__init__.py
@@ -1,0 +1,3 @@
+"""${{ .Inputs.description }}"""
+
+__all__ = ["main"]

--- a/repo-templates/python-app/skeleton/app/main.py
+++ b/repo-templates/python-app/skeleton/app/main.py
@@ -1,0 +1,43 @@
+"""${{ .Inputs.description }}
+
+Serves three endpoints:
+
+    GET /         the service identity and release
+    GET /healthz  liveness  — is the process alive
+    GET /readyz   readiness — is the process ready to take traffic
+
+The liveness and readiness endpoints are what the Helm chart in charts/app
+wires up as probes, so keep them cheap and dependency-free.
+"""
+
+import os
+
+from fastapi import FastAPI
+
+# Set at build time by CI: the git tag for a release, the short SHA otherwise,
+# so a running pod can always be traced back to a commit.
+RELEASE = os.environ.get("RELEASE", "dev")
+
+app = FastAPI(title="${{ .Inputs.serviceName }}", version=RELEASE)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/readyz")
+def readyz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    # BUCKET_NAME is set by the Helm chart from the storage component's output.
+    # The workload reaches the bucket through its own cloud identity, so there
+    # are no credentials to read here.
+    return {
+        "service": "${{ .Inputs.serviceName }}",
+        "release": RELEASE,
+        "bucket": os.environ.get("BUCKET_NAME", ""),
+    }

--- a/repo-templates/python-app/skeleton/charts/app/Chart.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: The workload for this service, deployed by the Wayfinder stack in Wayfinder.yaml.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/repo-templates/python-app/skeleton/charts/app/templates/_helpers.tpl
+++ b/repo-templates/python-app/skeleton/charts/app/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "app.serviceAccountName" -}}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.release | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/repo-templates/python-app/skeleton/charts/app/templates/deployment.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Rolls the pods when the release changes even if the image tag does not.
+        wayfinder.appvia.io/release: {{ .Values.release | quote }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ include "app.name" . }}
+          image: {{ required "image is required; it is supplied by CI as ${IMAGE}" .Values.image | quote }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.port | quote }}
+            - name: RELEASE
+              value: {{ .Values.release | quote }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/repo-templates/python-app/skeleton/charts/app/templates/httproute.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ required "httpRoute.parentGateway.name is required when httpRoute.enabled is true" .Values.httpRoute.parentGateway.name }}
+      {{- with .Values.httpRoute.parentGateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled is true" .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "app.fullname" . }}
+          port: {{ .Values.port }}
+{{- end }}

--- a/repo-templates/python-app/skeleton/charts/app/templates/service.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/repo-templates/python-app/skeleton/charts/app/templates/serviceaccount.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  # Wayfinder puts the cloud workload identity annotations here, which is how
+  # the pod authenticates to its cloud resources without any stored credentials.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/repo-templates/python-app/skeleton/charts/app/values.yaml
+++ b/repo-templates/python-app/skeleton/charts/app/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for a standalone `helm template`. In a real deployment every value
+# here is overwritten by the valuesTemplate in Wayfinder.yaml, which is where
+# the image tag, the workload identity annotations and the storage outputs come
+# from. Edit Wayfinder.yaml, not this file, unless you are adding a new value.
+
+# Container image reference. CI supplies this as ${IMAGE} at deploy time.
+image: ""
+
+# The release this is: a git tag, or sha-<short sha>.
+release: dev
+
+port: 8080
+replicas: 1
+
+serviceAccount:
+  name: app
+  # Wayfinder writes the cloud workload identity annotations here. That is what
+  # lets the pod reach its cloud resources with no credentials in the cluster.
+  annotations: {}
+
+# Environment variables for the container, as a plain name/value map.
+env: {}
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentGateway:
+    name: ""
+    # Leave blank when the Gateway is in this service's own namespace.
+    namespace: ""
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/repo-templates/python-app/skeleton/plans/aws-s3-data-bucket.yaml
+++ b/repo-templates/python-app/skeleton/plans/aws-s3-data-bucket.yaml
@@ -1,0 +1,144 @@
+apiVersion: cloudresources/v3
+kind: CloudResourcePlan
+metadata:
+  name: aws-s3-data-bucket
+  version: "1.0.0"
+spec:
+  cloud: aws
+  description: "S3 bucket for application data, with read-only / read-write / write-only consumption policies that other components can be granted."
+  inputs:
+    - name: versioning
+      description: "Enable object versioning. Use with caution — makes deletion harder."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: disable_force_destroy
+      description: "Disable force destroy. Use with caution — teardown will fail while objects remain."
+      type: bool
+      optional: true
+      defaultValue: false
+    - name: suffix
+      description: "Differentiates buckets within a stack instance. Combined with stack+instance to form the bucket prefix."
+      type: string
+      optional: true
+      defaultValue: "data"
+
+  # This is a PROVIDER plan: it has no workload identity of its own. Instead it
+  # publishes consumption policies that other components can be granted from the
+  # manifest. Wayfinder turns a grant into the IAM policy below and attaches it to
+  # the consumer's role — no IAM written by hand.
+  consumptionPolicies:
+    - name: read-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: read-write
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppReadWrite",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}",
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+    - name: write-only
+      grantPermissions:
+        aws:
+          customIAMPolicyTemplate: |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AppWriteOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": [
+                    "${{ .Outputs.s3_bucket_arn }}/*"
+                  ]
+                }
+              ]
+            }
+
+  terraform:
+    modules:
+      - name: s3_bucket
+        source: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+        version: "v4.1.2"
+    files:
+      - name: main.tf
+        template: |
+          module "s3_bucket" {
+            source = ${{ .Modules.s3_bucket.Source | quote }}
+
+            bucket_prefix = "${{ .Stack.Name }}-${{ .Stack.Instance.Name }}-${{ .Inputs.suffix }}-"
+
+            ${{- if .Inputs.versioning }}
+            versioning = {
+              enabled = true
+            }
+            ${{- end }}
+
+            server_side_encryption_configuration = {
+              rule = {
+                apply_server_side_encryption_by_default = {
+                  sse_algorithm = "AES256"
+                }
+              }
+            }
+
+            # AWS blocks public access on new buckets by default; don't attach a
+            # public policy (and avoid s3:PutBucketPublicAccessBlock, which some
+            # account guardrails deny).
+            attach_public_policy = false
+
+            ${{- if not .Inputs.disable_force_destroy }}
+            force_destroy = true
+            ${{- end }}
+
+            tags = {
+              Application = "${{ .Stack.Name }}"
+              Environment = "${{ .Stack.Instance.Name }}"
+              ManagedBy   = "Wayfinder"
+            }
+          }
+      - name: outputs.tf
+        template: |
+          output "s3_bucket_arn" {
+            value = module.s3_bucket.s3_bucket_arn
+          }
+          output "s3_bucket_id" {
+            value = module.s3_bucket.s3_bucket_id
+          }

--- a/repo-templates/python-app/skeleton/pyproject.toml
+++ b/repo-templates/python-app/skeleton/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "${{ .Inputs.serviceName }}"
+version = "0.1.0"
+description = "${{ .Inputs.description }}"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.0",
+    "httpx>=0.28.0",
+    "ruff>=0.9.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/repo-templates/python-app/skeleton/tests/test_main.py
+++ b/repo-templates/python-app/skeleton/tests/test_main.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize("path", ["/healthz", "/readyz"])
+def test_probes_report_ok(path: str) -> None:
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_root_reports_the_service_identity() -> None:
+    response = client.get("/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "${{ .Inputs.serviceName }}"
+    # Always reports something, even 'dev'.
+    assert body["release"]

--- a/repo-templates/python-app/skeleton/uv.lock
+++ b/repo-templates/python-app/skeleton/uv.lock
@@ -1,0 +1,636 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/72/fba934cb3dff7a85d811820efffcd141ddd52b5a2a01637f64551373ff4d/websockets-17.1.tar.gz", hash = "sha256:acfea4c20bf54384883ea33b1240fc1db4f52e190823a4e2b334bc3e8bfca96a", size = 187520, upload-time = "2026-08-26T17:25:33.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/31/5f6450a7879f4f063ef08897cc385ea3ce3f1fe17f08b11e3fd959abdf27/websockets-17.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a0162a6372110a5601cb5c9fd826635cedf69f3e110c545dd19774e040b970e", size = 217006, upload-time = "2026-08-26T14:56:10.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2a/c1b006fc861695d2aa4e35327b842015ce1d98cf8f99241829b3d6460bfc/websockets-17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:829dba1bc049779de9b332088c1a6a9858e96bd67e50b6b644a95e02b67836bc", size = 214690, upload-time = "2026-08-26T14:56:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/66e5b7d01445e0eeb1d4ab419c30315f2c90cf7a8a8cd4ecc47f894dba54/websockets-17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd8f47dbf2e8adb15c847215f83436de3fdb120b51fdae0fbbdf69fd97a3ad80", size = 214947, upload-time = "2026-08-26T14:56:12.923Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ce/033cafe2d2538562efa876b9149a2c7a0f7787870a4b1bb6e28adc9ceb6b/websockets-17.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9f4c0377a83e163a303514fdfab501dbe379bdc13e5b9312a91d112658b29dce", size = 224329, upload-time = "2026-08-26T14:56:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/e1c2e8a67f6cc0aa43abe0046fb3b7a020980649e6a843751dc7ce9eb170/websockets-17.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c3241d684a76eaaef8b2dc789afde4343cd3aad55ea81e4e8ab3605b529bae51", size = 224611, upload-time = "2026-08-26T14:56:15.702Z" },
+    { url = "https://files.pythonhosted.org/packages/be/de/07c6d48eb3d2069709410c851e7de10ab83d752c4bd09862899627c2729b/websockets-17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5f5c7a893507d0e83a80b88aefd6522f7e882cd53f9722c6f23f5a020c9557c", size = 225848, upload-time = "2026-08-26T14:56:16.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dd/3c68572d20509648cc2fb6f50ccf3deeb4b87270f2c8966e99476e278ea3/websockets-17.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:00bf34b64501e3477e81fc281532ff3cbf4da26633c10b63979d5085d46602d3", size = 227290, upload-time = "2026-08-26T14:56:18.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4a/8f6651c8a22093539c9215af0c5bbf217b87b382c99d2112039b92d593c2/websockets-17.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ce0305b702b20d1e1d60a9aaace6bc89970e1753565543f310d549eab22c2435", size = 226476, upload-time = "2026-08-26T14:56:19.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/f6fc33cea86b1127fd1297b18c107e81580ab55a73a39f9a934441ef321f/websockets-17.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29176d8b429cfa0fa443c473878d37a5c06cfd0cb36b71ba4314accc71e05906", size = 225233, upload-time = "2026-08-26T14:56:20.939Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/83/65edaf05f7c9b1dea82f4d252fdc37706a84571646f06119a27b0a16fe19/websockets-17.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3709a1ab30b4b922027d22f68d2b61a0656a91680ac894a537624e6be7dd7f7c", size = 222488, upload-time = "2026-08-26T14:56:22.208Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/d1169c2f7f1f0032b0d4b0c00f0711a070cd7c735de37bfeb876bc0f9606/websockets-17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:43bd0c1ceb924d67f5c1a5254d8361dd9d94246e6331a726064dfa2917880780", size = 225295, upload-time = "2026-08-26T14:56:23.445Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f4/64e2a386c3899b917c2933225c9b47887874229d159797f3bf1a11c20d51/websockets-17.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:1fce0f43e0d41422e0b2cad6561e1970df22f212f4c7e884967df7cf591b031c", size = 223891, upload-time = "2026-08-26T14:56:24.647Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b3/dfb5c482f7e310a3432fdbb045ddfe6d34114680e89a233d4ff900a32961/websockets-17.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4031152769179ab8dcdeafc7b0e58052a49117560a28671700b47b2c7b717aad", size = 224661, upload-time = "2026-08-26T14:56:26.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cf/94865130a336029f46412adc127c4fbe380f46172b90ce251369e35c4302/websockets-17.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a06f3b5085176763182449559e20391d7ce616a8972a9f7a33deda87ea6d4f3c", size = 225766, upload-time = "2026-08-26T14:56:27.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/eb8c658f86dfe562ed49a887a27424bfe9e618c26ea6f865b093d075d3a6/websockets-17.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:77b37cceca17291897c3c73bd30a7c7c7909593554b5da574ec852af83c1742a", size = 223323, upload-time = "2026-08-26T14:56:28.807Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7e/2629609652ece5ca0c7ac235927dd4511b08131e3a5d53439b798fddf002/websockets-17.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d8e83333385cac6030a5167fd18bf96cc6c58b914c308e683f05b0cf94bc8dd0", size = 224276, upload-time = "2026-08-26T14:56:29.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6b/8525737fe840b38e5f40956c198fb586a4fac1e07144d41a5b949b989cf8/websockets-17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:073c5c3f7e127041fa9d34a9e29ceefee8c3cafbd267ed2927318f425144380d", size = 224558, upload-time = "2026-08-26T14:56:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ab/3a958c6cbcf74b118f601c20a80ac8bd5e8dfec0bcf7345116feaeefb121/websockets-17.1-cp313-cp313-win32.whl", hash = "sha256:2afb58c7ba48b329d56769f8dfd89f394efe587b65ef806bae810a484d6d3608", size = 217475, upload-time = "2026-08-26T14:56:32.431Z" },
+    { url = "https://files.pythonhosted.org/packages/22/36/fb521f0f2994c25509651f169efe5582dddd8713d57a0757ba87859372ef/websockets-17.1-cp313-cp313-win_amd64.whl", hash = "sha256:0340bbef6bfbe16da888b3983d666a4db4954ac3253c38f13bc7aba0c7db5a2f", size = 217784, upload-time = "2026-08-26T14:56:33.608Z" },
+    { url = "https://files.pythonhosted.org/packages/68/92/9b8419584681a12a7534b746dfb2737c466efe2455483e2fbf8b941a04ec/websockets-17.1-cp313-cp313-win_arm64.whl", hash = "sha256:7a72efa3bf4fa3a6669a54420a472ad056da3973d827f10e3a536da463f926c2", size = 217715, upload-time = "2026-08-26T14:56:34.865Z" },
+    { url = "https://files.pythonhosted.org/packages/90/0d/500cf5daea09d4669dff3a7d67159094a0bd6c4ef130381404f6edd3eb5f/websockets-17.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0c9982938980e086da59f70d05f9418cd143401a601a0faac10fa48f7bb1cd3e", size = 217048, upload-time = "2026-08-26T14:56:36.03Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/5b12c6168aa269cffbfd24d177cd492b130120403a418c7e89462e27b4ac/websockets-17.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:57b39dc8541cf7ed3f639da82bf7451060483967f9e733da1f8173e4095f0642", size = 214737, upload-time = "2026-08-26T14:56:37.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/36/e453e5106e4e2416f008ac222837c2f1637a063b08008afcd1088889b631/websockets-17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:96abdecbaae746851b87c3a36cb4a661df93ca3d92f114270f79228bf1d00de6", size = 214955, upload-time = "2026-08-26T14:56:38.71Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/30/0204bb86176db02cdfc678ce65ed808a66fab87d250ce61a8790800a60b0/websockets-17.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d9fc873e239c5abeb150bc24dbd1a7af23a9254526383ce0a077f5e20adbeb19", size = 224331, upload-time = "2026-08-26T14:56:39.924Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/d8372256e00c4e3cab1115c45075d1eeedb642a3f2b42bd70c4deae03f06/websockets-17.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f42912fa9eb4cb7c7ec9fde9b3332ba339eb8a8811981043d4029599f3d950b", size = 224685, upload-time = "2026-08-26T14:56:41.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/7d/650355b8f67f908ff99603351d4458d1a0b787d627950a47c38db7e25308/websockets-17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f98bf378d7a5be047a044a1a27c987a8f355e10e3b5754617dbe756248cbc5ce", size = 225927, upload-time = "2026-08-26T14:56:42.359Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6c/a9ffa5b903579eed76017870f055d75ecc73988d9d0c9b65a92ba0bf2a27/websockets-17.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d334d11398086bb5559606cb42d51c013ea7c061c7db701521392373d3c087f5", size = 227300, upload-time = "2026-08-26T14:56:43.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/4551c2269066af7481ee44605a0813770961615b5b5da3e87a8f5cb859ea/websockets-17.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5c27336b1a0ac56569493e858497870347854372395f50483725f8cdacc5a45c", size = 226533, upload-time = "2026-08-26T14:56:44.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/237a99233e5c445759a613831b3a92e91905afc064dc3bd0ad33c35fd1e2/websockets-17.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67258b00302a5aaf0b267771c7014b13429abd7ea17eebc4c55bd935ff101555", size = 225280, upload-time = "2026-08-26T14:56:45.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b5/e9407a91613d1d1cd932414143a1012096b26674a782fc55a0bd23217ee4/websockets-17.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:455ffeea0879d313205df1e745e5883e1feb7f31ecd26be882f5f0babd3db04f", size = 222540, upload-time = "2026-08-26T14:56:47.053Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d2/db76628db0577b783205d9779f64d8e373416b04c62d1546be4b75dc8540/websockets-17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7233eaf441a345a5943a929fd4b5ea3278f11aed35a9ed0f3106b8cb3ca846a", size = 225354, upload-time = "2026-08-26T14:56:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4c/2174181c067b89a74ae18e2650c2ac29959f4b796afe876ab3f4d30d642c/websockets-17.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c65da239a5ad553619804c1f9d65c1a0b3005381c6158ee14da2c7444cbd0c78", size = 223867, upload-time = "2026-08-26T14:56:49.579Z" },
+    { url = "https://files.pythonhosted.org/packages/df/75/274decb9a8253561b5be3261e02a6676fc8ecdf31e95b722e53d5bfb8fd2/websockets-17.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9fa1ffa08c81a4f809cdab6129f8e55bee4650b9d6d3461019dda73aacd146b6", size = 224652, upload-time = "2026-08-26T14:56:50.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e6/49824f1fb4db7656d2f7492b1d8be16147b759d909490e32f4776843ee64/websockets-17.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:406b8107943a43ef4649b1e0cb0cdc052bbf08fe1c8905a623c4af9586e5cebb", size = 225822, upload-time = "2026-08-26T14:56:52.356Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/5dc43838c0b02a95f42c47a0de33c5ddd7767a9feeb4d0d8777ac1cfefe4/websockets-17.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:4e8ffcb486c8490a34a4cef5e4409d8da5a1cb1681e5bf7d786ce5e84aa8540d", size = 223379, upload-time = "2026-08-26T14:56:53.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/62/585637cf06d6b321232f79c55dc14d65518d12cf87c94c44f5864068810e/websockets-17.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fb88076df585b69c5761c387c0081aa87d7b9eb1b205a6535ca4777e25650d81", size = 224330, upload-time = "2026-08-26T14:56:55.184Z" },
+    { url = "https://files.pythonhosted.org/packages/de/68/c3b234a6a1366b6ab5bbfaa4434a1b946e1dc4e8ddd6824bfd93a8835b7f/websockets-17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5d4724255fb8398acd9e583b97eb2279cec20e0bd0f9a94bf75f6056ef9f13da", size = 224622, upload-time = "2026-08-26T14:56:56.393Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d4/84cf3d1376f5d8207f55f43c1c818babd6b89447f5dcd01f18a6d5526796/websockets-17.1-cp314-cp314-win32.whl", hash = "sha256:be3f0129c5654517b2abf07dcb75bb1d9479759a4ccfb569e8293579e9fc029a", size = 217036, upload-time = "2026-08-26T14:56:57.652Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0f/9e7ac63c5d7cb642952200814f584318e65146df008b7d375d5d9c6b2c97/websockets-17.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a4dc6ef83f4559e0d05f313a375cb38f63c986096a9da99fe94fdd779d313e5", size = 217382, upload-time = "2026-08-26T14:56:59.065Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/1ae6b91f7f3ac05f5c9f14a72dc2181c115ff370bcd8a7f10f02c174adfd/websockets-17.1-cp314-cp314-win_arm64.whl", hash = "sha256:46c0331c9eaaf73a559f3a9e388466be0df96eb83d40f06f1ca6ab6613b35c82", size = 217268, upload-time = "2026-08-26T14:57:00.654Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f0/f65644d0e0b2b90918a8c41503841cc4072a58f2bf76c09bc36e751fc0dd/websockets-17.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d411ea5ca18ac1b12c0c94be88b60c18ca641ac43bcdfdf1c9f79d46cdbe1603", size = 217379, upload-time = "2026-08-26T14:57:02.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/35/4c46d1f620ac1a30f92b6eae78ee40a772a93f568647ca7ccdc5ea283cf8/websockets-17.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:07fa3e7c30e2c577928d359b56bf872a3e0cbcc15553eaa0907c1ee86344b56f", size = 214911, upload-time = "2026-08-26T14:57:03.478Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6e/4587e8406d7c1188e97b9cf466c081e93399380d447f885bfce81626cd37/websockets-17.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6de9acef07e3a78e9567fcd26c29011a4da8f050b13004bbf880a0fd82a6eea5", size = 215115, upload-time = "2026-08-26T14:57:04.692Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/06/1381c8fff525041025909eb80ace32489194a00ba22a0a8d428030afcc84/websockets-17.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ea0ed9373b880115911d9d39634bccc95b8ce590c9c42e8589f5cacc3ef3cee2", size = 224696, upload-time = "2026-08-26T14:57:05.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9d/9034e867dc85340be058619751742b895f722326e83100d110063461ca07/websockets-17.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50903d335bfda026c2fa11dd9aed09d8cbee0c451e3a85122a9acb041b7dc69b", size = 224975, upload-time = "2026-08-26T14:57:07.262Z" },
+    { url = "https://files.pythonhosted.org/packages/40/eb/ed03aa3cae748ebf6397e5d44028f433f746bad09dc568ff754fda3a3c9b/websockets-17.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a74531ce81af587f906ab42f194032388fcff8fc7938402e5917c9147a39441", size = 226151, upload-time = "2026-08-26T14:57:08.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c9/cc1964a096d16f3b73cb1ee5f14f277f5a3bcac07c6e8f9a1dcded99f4c8/websockets-17.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8fbf28e639544503b7d1c96452a5e5e043e4108d89b1f3fa02910603622d19db", size = 228292, upload-time = "2026-08-26T14:57:09.846Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/26/46da6dd0363c2db2e4876fd59a40fd40c1943a82d7018d0a33afbce47d52/websockets-17.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f612dc57f00c07cf4aa2673f7cbceabd654ad2457b7e639f061b794d6e11f9fd", size = 226722, upload-time = "2026-08-26T14:57:11.118Z" },
+    { url = "https://files.pythonhosted.org/packages/78/98/ecd8f5e1c5d0e54c08ebc5c66852271112166db68107cb0e17ca1bf25009/websockets-17.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c7ac77401227212dc6e849182feee50d57cf456ec6329ffd6979c94bb136c5c", size = 225451, upload-time = "2026-08-26T14:57:12.601Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4d/da8d2760db53e17aae763738b6ba834b1fcf16813d3632f3edb6951e1ec8/websockets-17.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32a2a68d989d6e5b74a9d5095415c51189ebae29fceb7cf2b64a1c0318a81256", size = 223003, upload-time = "2026-08-26T14:57:13.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/40/ea401c141a79c5b1d0021a0dab9d0df2051c108f1620fbb39a6e7c714c3b/websockets-17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:aec00f018d34c67500ff0438dc314b40277be4a1b983cbacbf53ccf7db63e257", size = 225704, upload-time = "2026-08-26T14:57:15.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8e/07ab3f44215d89840d5385fdcaaab1fed8caeffa67c6899e15062957c12c/websockets-17.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0014eaff8ad5b3b43feda2279f9d34bf2eaae040720b9fbbb55944b10f40b14d", size = 224192, upload-time = "2026-08-26T14:57:16.3Z" },
+    { url = "https://files.pythonhosted.org/packages/58/93/ccf1af0a23e5748d4e22292a377d78d15cf294d7e707bbb11a8990ae6bd5/websockets-17.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:db9d7ee47f3ba531e278be539af39e2c7c7d28fb94897b6cd1120d63b0ef5922", size = 225082, upload-time = "2026-08-26T14:57:17.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/db/e32200f99ce282e728d2929f2c429db353cf3282db7d0eba99eb32c9fec1/websockets-17.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:ff3e2ba7a9f0a110b0555452e9b5a03a34e11662544e01beea15f144b48ba7b7", size = 226101, upload-time = "2026-08-26T14:57:18.802Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3d/e7a6e9777b29433620167c98f3caaff0d6b08b1239a273ef7f7fd1393349/websockets-17.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6da17fc94bd270f5987b10bee113461ac36a36a98b0481ddcc98056e5a90001a", size = 223794, upload-time = "2026-08-26T14:57:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/48/05/ac569090726dedd6656f3ee28b0c02dfb1ba76e898dceaccc2987a237cef/websockets-17.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:e8dc3fa6d6b7ead3f9de57895f41b116a28787548e066365d9d90f7356bcaad2", size = 224567, upload-time = "2026-08-26T14:57:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/14/50/4ef62941111db6b31193f4fabbb65f845a5177579040cb8fe0d774d25034/websockets-17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b65d5fe48219dc2d5e158de9e6514e75600f379cc7e37108d35f31764c155566", size = 224993, upload-time = "2026-08-26T14:57:22.86Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/2b95ada4ea19bf3a2072b68669ce4f4afb212690b727d31640576287fd68/websockets-17.1-cp314-cp314t-win32.whl", hash = "sha256:2cce251f3e2469b99b6802b55435bcdd07123b41870f54c87b336183af9d7e68", size = 217168, upload-time = "2026-08-26T14:57:24.466Z" },
+    { url = "https://files.pythonhosted.org/packages/32/0a/67d5ee08dd8060a37d612fd40a625b5376ad19ae48fe1c8ad428c278b817/websockets-17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8f6c38cdcaf98a911d7acc25577f2f9e710f3a2fc2bde1563556784320196b51", size = 217508, upload-time = "2026-08-26T14:57:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/822005d0c674451d2411027b878cdc128a2b7ea5a30d337d9e279da22eba/websockets-17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:d1e2f5fa2b6d01f0d85b4f223fea7ed1d504be282a02a81bd2be4817ef7a2f03", size = 217425, upload-time = "2026-08-26T14:57:27.324Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d5/99a6c6a1eb5d5ae9f45f59a3c97f4e3b21f310eb404a547fb3e7d2fc054c/websockets-17.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:88381602e379165b66244b2ebc29f9b23ea0851fbe63ae157f91ca324f072d6f", size = 216970, upload-time = "2026-08-26T14:57:28.575Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/1e7f6e833728193958d3ed3d67b5d57c3c7cfa948abf94d4bc553257c954/websockets-17.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:88bc5138e53903a85c354e59df7ba73ce306f7b09724cef74dba121e60a88ce2", size = 214699, upload-time = "2026-08-26T14:57:29.862Z" },
+    { url = "https://files.pythonhosted.org/packages/07/00/95d39549f86e34425a0412bcbe61708dd1fc46af654e2134a6c4389102ad/websockets-17.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:3546ef55b3a074494106508bc6505c73825970d2d9505f7bf53882b3e88b0d1e", size = 214927, upload-time = "2026-08-26T14:57:31.148Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/b442415fc4f7f9943b0fc8e8eebaa13923ca73361e167c439ba634eecbd9/websockets-17.1-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9ae55d24241fc055f22aea3ac924559069848bd0ad4ea065fdd72d2194685fe8", size = 224373, upload-time = "2026-08-26T14:57:32.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/dd/b83537aae4cf61615b9d8b2dbb235c0030ba85457a6d934798273814600f/websockets-17.1-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7b349265fad6244013eecd99df8d83c12bf3013943e431f4fadd5bffc37db42", size = 224801, upload-time = "2026-08-26T14:57:34.041Z" },
+    { url = "https://files.pythonhosted.org/packages/76/83/5ab0abed58454909e8dbab45086ac68ee4556d7a8ada26735addc909b903/websockets-17.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc5789e5ea182b77a38881383ada5347202a6c66f4857d054e075290e80b604b", size = 225967, upload-time = "2026-08-26T14:57:35.292Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/26/e2412f2b998a8c1dfc00c0709ff6ee0c634dd0b0b4f92bdfe9667876b71c/websockets-17.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce13c7d233239e739600a57d4a73c1192ad8259e655a4d55aa1a454242bc809d", size = 227664, upload-time = "2026-08-26T14:57:36.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/25/0dd4495df3c0e02f6db705312ba85ab9b2dd42257dc23eb0da10066e4844/websockets-17.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1036189bd34b0bc1b10a4679321e2c7968af317efe6e8e4c1c5141c4254fb5bb", size = 226447, upload-time = "2026-08-26T14:57:37.781Z" },
+    { url = "https://files.pythonhosted.org/packages/be/67/6df3f63ffc48f08126ed0cd2fd2a41092967c3e364f8ec100deae90b6d77/websockets-17.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e78fd4b7b2c5086a38671c9c882c1e643385eccea360b5b1fda4a105e590087e", size = 225343, upload-time = "2026-08-26T14:57:39.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8d/a8479bbb09ff054907d141123d8f52fb6ae5ac39c6dbe39e6a02a8408309/websockets-17.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:46e7a10bf04318c7b0c0273791925ae5e1cbe4a11e34aa934d2ef27862058a80", size = 222748, upload-time = "2026-08-26T14:57:40.478Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fb/4c3d2a3269cde3f3087916de9c3d9fc5d7196b46846d8c3a9ae59ad0a884/websockets-17.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:33e45c7ea38428e740a7f233555d71df0b875cef7fc080acebc9654475e35335", size = 225453, upload-time = "2026-08-26T14:57:41.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1c/6467b401d19408f34e1c7389c222c2c7e1dfdf08c551190269b5eabc726c/websockets-17.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:6e63c01803be425ff062b7f7fc201a74def1d49fc94a2410dd17375df75936e9", size = 224112, upload-time = "2026-08-26T14:57:43.136Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5f/744e032ac80e11039a7447657ebabb46e9b5c2dbcec83be571335212932f/websockets-17.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:722ec21717eec6477bce582147a28acdfe034e604239466a6a95daedb863e774", size = 224646, upload-time = "2026-08-26T14:57:44.871Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/47/bcb9128d9afc4d0934d9192e2a24897ca2f7a63df2654904915349c6c46d/websockets-17.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:e74e41f0ad12ff1e8983e349daef79d37cc8280c743ce9d134d6c74c18dab5d6", size = 225797, upload-time = "2026-08-26T14:57:46.338Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/e0/b058047b7cf565e1105b10ef6b6b24a6ebe3575678c7dc75a645334705a7/websockets-17.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:12fe8984a32dbfd084e0603f1a8d740c0180cb85b3174585c54a80d2455a8394", size = 223605, upload-time = "2026-08-26T14:57:48.175Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/69/fc1555bff884de363f1bf9eebf2836dbeb29fa7e4f957debb7bbcf43abba/websockets-17.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:01dcb47deebc40b38fd4a493b9b9f4d0a704b7bec6f35e4d34085b329abce71a", size = 224508, upload-time = "2026-08-26T14:57:49.407Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/648d4e68621688b19093b06f7b497d520952e68cdea1c1b54371fe9491de/websockets-17.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f4c45ee2512d3757b5e6c67c5a34e435143f2ecb7df3324f9fd888688c45c0f4", size = 224767, upload-time = "2026-08-26T14:57:50.799Z" },
+    { url = "https://files.pythonhosted.org/packages/58/93/f8342b55864f71df13eb8e9ef7dce691b87a87f04f75bb8a1385b3336e7c/websockets-17.1-cp315-cp315-win32.whl", hash = "sha256:0f4f50dfe2cc810fc4e2de979b35e83bf8bb4bccdc6fe472d93762ea7b1d5927", size = 217003, upload-time = "2026-08-26T14:57:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f0/7b5fdb774c245e0b6217009e2a24d2105c1a64923949f33be41aa7959302/websockets-17.1-cp315-cp315-win_amd64.whl", hash = "sha256:4af784f3e436f65b355c117c6497320f2b5cf6a559295cb1c4c7338e335d45cc", size = 217300, upload-time = "2026-08-26T14:57:53.492Z" },
+    { url = "https://files.pythonhosted.org/packages/76/33/1fe6ed1b5087516115ca451b2c240314b010647071f8fc3bd78a21e4dddb/websockets-17.1-cp315-cp315-win_arm64.whl", hash = "sha256:d58159af7835fde09c462394293c0d7aaf8fb4557d8f8e5699f5e722ccae013d", size = 217214, upload-time = "2026-08-26T14:57:54.88Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ca/ed02e75996a266d76c5fcb5dd9b930db4cf2b388ca5fa3d2a72086f81568/websockets-17.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1a5cf4e7bbe3ca499e6a289206cb4fcb7444b09919e129bd517f57d5fa192c13", size = 217282, upload-time = "2026-08-26T14:57:56.108Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7d/d536f5bc89ea5b52fd1c1727c59fabafee6bc41f5ce92c3bd2f83047908c/websockets-17.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:416b4bc8789a1865a3ff643ec4ee073a5f52402d0dbeafd27b1798d5dd6b6a51", size = 214863, upload-time = "2026-08-26T14:57:57.355Z" },
+    { url = "https://files.pythonhosted.org/packages/37/37/944cf17bad668e9be1247e6314f88a48b9faf7c250e383410db8b38af0b9/websockets-17.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:259f45358c76d3b18489e3e80636cdbe807e05ecf1b10fdf1a779106d23d0c8e", size = 215073, upload-time = "2026-08-26T14:57:58.719Z" },
+    { url = "https://files.pythonhosted.org/packages/74/bf/3267966cc1bbc2b8fa62fd329651b0af502df1f5d1c0eed027ff339d6aa8/websockets-17.1-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d9d01e8ede41fea4f5a847dad9d628355f74905f437a5b6856d67aa66d193800", size = 225229, upload-time = "2026-08-26T14:58:00.235Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d8/85ea722f483510abb39fc71aafb4465d17cf9051a275ab036874ff3c300c/websockets-17.1-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a7b35181a14cbfcae163b4de545d22abfd07d06c2c41ca69cfcd99251d6888ab", size = 225500, upload-time = "2026-08-26T14:58:01.994Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ce/64c7d00005bd0d15ecb5c5fcb7fb2597b6b92ddd16c4fa6bbc3d2835ad63/websockets-17.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a8e768a048c2220697477ce2e67e4345dc9f693d0ee6af53945b5e30227c6a7", size = 226829, upload-time = "2026-08-26T14:58:03.327Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/dc/096c67940fb957e667ca3c542818150434eb0388c6fdc90b3a502f3c3e96/websockets-17.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:880069d21cc33a558dcf180924a546d1ecf8ada5be3e4e70acee87019d706a24", size = 228457, upload-time = "2026-08-26T14:58:04.78Z" },
+    { url = "https://files.pythonhosted.org/packages/51/fe/f2331b6b7ccc67589891da354fa46a5cb79e95f83b9fd0e734d77f1f2140/websockets-17.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cec1bb8f22abccc8d20f8ca63df9be41600c26c190f4b97ee86c675fd4a863a6", size = 227265, upload-time = "2026-08-26T14:58:06.102Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a5/fb1642302f8ec77ca922203074f155a9831a5128ad75e725059a476d1227/websockets-17.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f3a1d577e081667dda7f8e5b4796e6e32f9713c93e2a3d930669519840a3c623", size = 226143, upload-time = "2026-08-26T14:58:07.464Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/41/7133fcfb63f5562750b269d6a845c689dde6a2c6407286da395beea19ddd/websockets-17.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc053f9e95a76213c5eb7ed95779f7daf0d2bf0e4e03073629ebfa43a033f151", size = 223501, upload-time = "2026-08-26T14:58:08.766Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b1/82b36bfabc79ff2d383a1fc043cee6a13f794ef4f6bf1b4810ad6988cf6f/websockets-17.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:bb0efe019480a1c93e168ce96479273aaebd672fc8c350d5eed1e507ababb1b8", size = 226330, upload-time = "2026-08-26T14:58:09.987Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7d/5b511b9bf6e9ad331e6ff902fcbcc71c3794d10ef3b5efe80ccb8f0a7861/websockets-17.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:615746b12b26a3fd4077bc6fbeb277a1c192a45dd57b531d07ad9ed5c52a9a7a", size = 224980, upload-time = "2026-08-26T14:58:11.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/aed08f25301f8eef23be903ff9319fcf35630ca2bdec9d226f7d804dd5b3/websockets-17.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:1a20136d61f9ca3a31493732762661fafc2c20e8861930214e21afc6a8a692a2", size = 225478, upload-time = "2026-08-26T14:58:12.543Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/47/0d63d4168536b4682c9d19b7399443b1176f25dbb68878374fa716670230/websockets-17.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:2786cbd273ab69c22612db8a41229ddf2c158060b17b5928884bf388d07887f3", size = 226588, upload-time = "2026-08-26T14:58:14.457Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/844bd0b6386fc81ed6a55f4b6dd26f01c6987eda205afa10175ea12b2164/websockets-17.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:b1c323fc3be1dc3f87f6c59458cb7d9e13dcbbf971d6c3f3e2bbaf58d3bfcdfe", size = 224336, upload-time = "2026-08-26T14:58:15.778Z" },
+    { url = "https://files.pythonhosted.org/packages/96/18/03709c84bc88ec4dcea68d4be4ccd07d611073dec111203a5bf45af8809d/websockets-17.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:12c8e2b25df59755954a04dfa09c990b96691025aaf7eafd19ed6da24b09c18d", size = 225197, upload-time = "2026-08-26T14:58:17.141Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cf/0d1c694b6466c89e875b85b32b51312c472cf6708eee91914866f5087dde/websockets-17.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f58f58b4b29bbea2a3635e2c56eff4a3adab011fe383802a9e542e31b97085fc", size = 225493, upload-time = "2026-08-26T14:58:18.521Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f5/99857c3dd9676749f33e3668665a34ad6099505fb8d75eb084f49f7807a9/websockets-17.1-cp315-cp315t-win32.whl", hash = "sha256:f78a3ffb1994304db2c0c4588e4d1a518079b557054fa3bb985a6f5e50ff49a3", size = 217130, upload-time = "2026-08-26T14:58:20.037Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/84/77599922ab441bfe61508f97dab2c71f8e114d31793993ea54011db16199/websockets-17.1-cp315-cp315t-win_amd64.whl", hash = "sha256:ad68c28a27246fed109a4409393d677b7e1388345cbbd2f5aee5c182d8506110", size = 217448, upload-time = "2026-08-26T14:58:21.382Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3c/8b9a225b523f06a9389be81f1b0ab07c49bec6014742e6aa359c1f920f1f/websockets-17.1-cp315-cp315t-win_arm64.whl", hash = "sha256:e552e0037230ac16e5f568de7012041344d1b18c9feed30ec2891b8eba55af81", size = 217372, upload-time = "2026-08-26T14:58:22.807Z" },
+    { url = "https://files.pythonhosted.org/packages/41/63/23572870e01836a98346075b9e17a8bc24a6ddd9800a3204ceee58677f3c/websockets-17.1-py3-none-any.whl", hash = "sha256:f221081107b8c48184d99f7019604486376e7ef826037e70aad6b02540732c23", size = 211134, upload-time = "2026-08-26T17:25:31.397Z" },
+]
+
+[[package]]
+name = "${{ .Inputs.serviceName }}"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "pytest", specifier = ">=8.3.0" },
+    { name = "ruff", specifier = ">=0.9.0" },
+]

--- a/repo-templates/python-app/wayfinder-template.yaml
+++ b/repo-templates/python-app/wayfinder-template.yaml
@@ -1,0 +1,145 @@
+# Wayfinder repo template definition.
+#
+# Parsed strictly: an unrecognised key here is an error, not a warning.
+# Everything under skeleton/ is what gets written into the new repository.
+name: Python FastAPI service
+description: >-
+  A Python HTTP service on FastAPI, managed with uv, deployed by a Wayfinder
+  stack that runs the app on Kubernetes alongside an S3 bucket it reaches
+  through workload identity. Ships the standard Wayfinder CI set: pull request
+  previews, deploy to develop on merge, and deploy to production on a tag.
+icon: python
+
+inputs:
+  # The only required input. Everything else has a default so the template can
+  # be scaffolded from the catalogue, or from CI with --no-input, by supplying
+  # nothing but a name.
+  - name: serviceName
+    description: >-
+      Name of the service. Used for the Go command package, the container image,
+      the Helm release and the develop and production stack instance names.
+    type: string
+    minLength: 2
+    maxLength: 40
+    pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+
+  - name: description
+    description: One line describing what this service does.
+    type: string
+    optional: true
+    defaultValue: "A Python FastAPI service scaffolded by Wayfinder"
+    maxLength: 200
+
+  - name: owner
+    description: Team that owns this service. Written into the README and CODEOWNERS.
+    type: string
+    optional: true
+    defaultValue: ""
+    maxLength: 60
+
+  # The scaffold context has no workspace, so CI needs to be told which one to
+  # deploy into. Leave blank to fall back to the WF_WORKSPACE GitHub variable,
+  # which is the better choice when one workspace serves many repositories.
+  - name: workspace
+    description: >-
+      Wayfinder workspace CI deploys into. Leave blank to take it from the
+      WF_WORKSPACE GitHub repository or organisation variable instead.
+    type: string
+    optional: true
+    defaultValue: ""
+    pattern: "^([a-z][a-z0-9-]*[a-z0-9])?$"
+
+  - name: developEnvironment
+    description: Environment deployed to on every merge to the default branch.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: prodEnvironment
+    description: Environment deployed to when a release tag is pushed.
+    type: string
+    optional: true
+    defaultValue: "prod"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: previewEnvironment
+    description: Environment pull request preview instances are created in.
+    type: string
+    optional: true
+    defaultValue: "dev"
+    pattern: "^[a-z][a-z0-9-]*$"
+
+  - name: registry
+    description: Container registry the service image is published to.
+    type: string
+    optional: true
+    defaultValue: "ghcr.io"
+    enum: ["ghcr.io", "quay.io", "docker.io"]
+
+  - name: port
+    description: TCP port the service listens on.
+    type: number
+    optional: true
+    defaultValue: 8080
+    minimum: 1
+    maximum: 65535
+
+  - name: includeStorage
+    description: >-
+      Provision an S3 bucket alongside the service and grant the workload
+      read-write access to it through workload identity.
+    type: bool
+    optional: true
+    defaultValue: true
+
+  - name: storagePlan
+    description: >-
+      CloudResourcePlan backing the storage component. Defaults to the plan
+      bundled in the generated repository, so the stack deploys with no
+      catalogue prerequisite. Set it to a catalogue reference such as
+      aws-s3-data-bucket@1.0.0 to use your platform team's plan instead.
+    type: string
+    optional: true
+    defaultValue: "file:plans/aws-s3-data-bucket.yaml"
+
+  # Exposing the service needs a Gateway that already exists in the target
+  # environment, which only the platform team knows. With no gateway named, the
+  # service still deploys but is reachable only inside the cluster.
+  - name: gatewayName
+    description: >-
+      Name of an existing Gateway API Gateway to publish the service through.
+      Leave blank to deploy without an HTTPRoute, reachable in-cluster only.
+    type: string
+    optional: true
+    defaultValue: ""
+
+  - name: gatewayNamespace
+    description: >-
+      Namespace of the Gateway named in gatewayName. Leave blank when the
+      Gateway is in the same namespace as the service.
+    type: string
+    optional: true
+    defaultValue: ""
+
+skeleton:
+  path: skeleton
+
+  # Files listed here are copied byte for byte. Their contents are NOT rendered,
+  # so they must not use the `$${{ }}` escape either — it would land literally.
+  #
+  # Note that these globs are matched with path.Match: `**` is not supported, and
+  # `*.yaml` does not match `*.yml`, which is why both are listed.
+  raw:
+    # GitHub Actions has its own ${{ }} expression syntax. Keeping the workflows
+    # raw means they are valid Actions YAML exactly as written, both here and in
+    # the generated repository. Per-repository values reach them through
+    # .wayfinder/ci.env, which is rendered.
+    - ".github/workflows/*.yaml"
+    - ".github/workflows/*.yml"
+    - ".wayfinder/*.sh"
+    # Helm charts are Helm templating, evaluated at deploy time, not now.
+    - "charts/app/*"
+    - "charts/app/templates/*"
+    # CloudResourcePlans use the Wayfinder stack template engine, not this one.
+    - "plans/*.yaml"

--- a/repo-templates/setup-ci-service-accounts.sh
+++ b/repo-templates/setup-ci-service-accounts.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Creates the three Wayfinder service accounts a scaffolded repository needs,
+# one per environment, each trusting a different GitHub OIDC subject.
+#
+#   usage: TENANT=acme WORKSPACE=team-a REPO=acme/payments SERVICE=payments \
+#            ./setup-ci-service-accounts.sh
+#
+# The separation is the point: the credential a pull request can use must not be
+# able to deploy to production. Nothing long-lived is stored in the repository —
+# GitHub mints a short-lived identity token per workflow run and Wayfinder
+# exchanges it, so there is no secret to leak or rotate.
+set -euo pipefail
+
+TENANT="${TENANT:?set TENANT, e.g. acme}"
+WORKSPACE="${WORKSPACE:?set WORKSPACE, e.g. team-a}"
+REPO="${REPO:?set REPO in owner/repo form, e.g. acme/payments}"
+SERVICE="${SERVICE:?set SERVICE, the serviceName you scaffolded with}"
+
+DEVELOP_ENV="${DEVELOP_ENV:-dev}"
+PREVIEW_ENV="${PREVIEW_ENV:-dev}"
+PROD_ENV="${PROD_ENV:-prod}"
+
+# account name : environment : the GitHub subject restriction it trusts
+#
+# --github-pull-request  matches only workflow runs triggered by a pull request.
+# --github-environment   matches only a job that declares that environment, so
+#                        the GitHub approval gate is enforced by the token
+#                        itself rather than only by the UI.
+create() {
+  local name="$1" env="$2"
+  shift 2
+
+  echo "==> ${name} (${env})"
+  wf create serviceaccount "${name}" -w "${WORKSPACE}" || true
+
+  wf create serviceaccountcredential "github" \
+    --service-account "${TENANT}:${WORKSPACE}:${name}" \
+    --github-repo "${REPO}" \
+    "$@"
+
+  wf grant role deployer \
+    --to "ServiceAccount:${TENANT}:${WORKSPACE}:${name}" \
+    -w "${WORKSPACE}" -e "${env}"
+}
+
+create "${SERVICE}-ci-preview" "${PREVIEW_ENV}" --github-pull-request
+create "${SERVICE}-ci-develop" "${DEVELOP_ENV}" --github-environment develop
+create "${SERVICE}-ci-prod" "${PROD_ENV}" --github-environment production
+
+cat <<EOF
+
+Done. Two things are still needed before CI can deploy:
+
+  1. The preview account needs catalogue write in ${WORKSPACE}. Wayfinder.yaml
+     refers to its plan as file:plans/..., which publishes that plan to the
+     workspace catalogue — including on the dry run the validate job does.
+     Grant it, or point the storagePlan input at a catalogue reference instead.
+
+  2. GitHub environments named 'develop' and 'production' must exist on
+     ${REPO}, with your reviewers on 'production'. Without them GitHub will not
+     mint the environment-scoped token these credentials trust.
+EOF


### PR DESCRIPTION
## Summary

Adds five golden-path service templates — `go-app`, `python-app`, `node-app`, `java-app`, `dotnet-app` — alongside the existing teaching examples. Each scaffolds a repository that builds a container image and deploys itself through Wayfinder, arriving with a working delivery pipeline rather than just a CI build.

- **Pull request** → test, build, `wf deploy --dry-run` validate, deploy a preview instance `<service>-pr<N>`, comment the URL. Destroyed when the PR closes.
- **Merge to main** → build `sha-<short sha>`, deploy `<service>-develop`.
- **Tag `v*`** → build the tagged tree as `<image>:<tag>`, deploy that exact tag to `<service>-prod` behind a GitHub environment gate and, optionally, a Wayfinder plan-approval gate.

The stack is an app KubeResource plus an S3 CloudResource wired by workload identity, so no credential exists anywhere in the generated repository.

## How they hold together

- The four workflows are **byte-identical across all five templates** and are `raw`, so they are valid Actions YAML on disk and `actionlint` can lint them directly. Per-repository values reach them through a rendered `.wayfinder/ci.env`.
- Language differences live entirely in the `Makefile` (`ci-setup`/`test`/`lint`/`build`). That is what lets the workflows stay identical.
- One shared inputs contract; `serviceName` is the only required input, so a `--no-input` CI scaffold works.

## Naming

Named `*-app` to avoid colliding with the existing `go-service`. The teaching examples keep their role — each demonstrates one mechanic — and the README now separates the two sets.

Also fixes `go-service/wayfinder-template.yaml` declaring `name: Go microservice`, identical to `go-microservice`, which showed two rows with the same name in the catalogue.

## Checks added

`.github/workflows/validate-repo-templates.yaml` runs, on every change:

- `hack/check-templates.py` — manifest parses, README present, no `wayfinder-stack.yaml`, fetch limits, no symlinks, shared inputs contract, workflow drift, and **no foreign `${{ }}` left bare in a rendered file**. That last one catches a real bug in either convention: a missing `raw` glob, or a missed `$${{` escape.
- `actionlint` over the shared workflows, `shellcheck`, `helm lint` + `helm template` in both shapes.
- Render each skeleton with `hack/render-for-build.sh`, then `make ci-setup && make lint && make test` and a container build.

## Verified locally

All of the above, plus the real render through Wayfinder’s own engine (`WF_EXAMPLES_DIR=... go test -run Example` in the wayfinder repo) — which also covers `includeStorage=false` and a fully-specified input set.

## Licensing

Everything here is written from scratch, so the repository takes on no attribution obligations and nothing is blocked. I had planned to adapt the MIT-licensed HMCTS Spring Boot template for Java and wrote our own instead, which keeps that decision open rather than forcing it.

The repository still has no `LICENSE`. Worth adding before anything here is adapted from elsewhere — Apache-2.0 is the natural fit, since MIT content can be sublicensed into it and not the reverse.

## Java and .NET specifics

Both fix their package/assembly name (`com.example.app`, `Service`) rather than templating it. Renaming is one IDE refactor; templating threads a name through the build, the tests and the container entrypoint for no real gain.

Two things caught in review that are worth knowing:

- **Docker's `ARG VERSION` collides with MSBuild.** A build arg becomes an environment variable, and MSBuild reads environment variables as properties — so `VERSION=v1.2.3` was taken as the assembly version and failed the publish. Unset for that one command, with a comment saying why.
- **No Maven wrapper**, deliberately: runners ship Maven and the container build uses a Maven base image, so a wrapper is one more thing to keep current.

